### PR TITLE
docs: add ShieldsIO tags to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@
 
 A comprehensive React UI components library based on the [Arco Design](https://arco.design/mobile/react) system.
 
+![](https://img.shields.io/badge/-Less-%23CC6699?style=flat-square&logo=sass&logoColor=ffffff)
+![](https://img.shields.io/badge/-Typescript-blue?logo=typescript&logoColor=white)
+![](https://img.shields.io/badge/-React.js-blue?logo=react&logoColor=white)
+
+    
+![](https://img.shields.io/npm/v/@arco-design/mobile-react.svg?style=flat-square)
+![](https://img.shields.io/npm/dm/@arco-design/mobile-react.svg?style=flat-square)
 [![license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/arco-design/arco-design-mobile/blob/main/LICENSE)
 
 </div>

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A comprehensive React UI components library based on the [Arco Design](https://a
 ![](https://img.shields.io/badge/-Typescript-blue?logo=typescript&logoColor=white)
 ![](https://img.shields.io/badge/-React.js-blue?logo=react&logoColor=white)
 
-    
+
 ![](https://img.shields.io/npm/v/@arco-design/mobile-react.svg?style=flat-square)
 ![](https://img.shields.io/npm/dm/@arco-design/mobile-react.svg?style=flat-square)
 [![license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/arco-design/arco-design-mobile/blob/main/LICENSE)
@@ -94,3 +94,5 @@ Thank you to all the people who already contributed to Arco Design Mobile!
 # License
 
 This project is [MIT licensed](./LICENSE).
+
+[![Star History Chart](https://api.star-history.com/svg?repos=arco-design/arco-design-mobile&type=Date)](https://star-history.com/#arco-design/arco-design-mobile&Date)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -11,6 +11,14 @@
 
 基于 [Arco Design](https://arco.design/mobile/react) 的 React UI 组件库。
 
+    
+![](https://img.shields.io/badge/-Less-%23CC6699?style=flat-square&logo=sass&logoColor=ffffff)
+![](https://img.shields.io/badge/-Typescript-blue?logo=typescript&logoColor=white)
+![](https://img.shields.io/badge/-React.js-blue?logo=react&logoColor=white)
+
+    
+![](https://img.shields.io/npm/v/@arco-design/mobile-react.svg?style=flat-square)
+![](https://img.shields.io/npm/dm/@arco-design/mobile-react.svg?style=flat-square)
 [![license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/arco-design/arco-design-mobile/blob/main/LICENSE)
 
 </div>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -11,12 +11,12 @@
 
 基于 [Arco Design](https://arco.design/mobile/react) 的 React UI 组件库。
 
-    
+
 ![](https://img.shields.io/badge/-Less-%23CC6699?style=flat-square&logo=sass&logoColor=ffffff)
 ![](https://img.shields.io/badge/-Typescript-blue?logo=typescript&logoColor=white)
 ![](https://img.shields.io/badge/-React.js-blue?logo=react&logoColor=white)
 
-    
+
 ![](https://img.shields.io/npm/v/@arco-design/mobile-react.svg?style=flat-square)
 ![](https://img.shields.io/npm/dm/@arco-design/mobile-react.svg?style=flat-square)
 [![license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/arco-design/arco-design-mobile/blob/main/LICENSE)
@@ -94,3 +94,5 @@ ReactDOM.render(<App />, document.getElementById('app'));
 # License
 
 [MIT 协议](./LICENSE)
+
+[![Star History Chart](https://api.star-history.com/svg?repos=arco-design/arco-design-mobile&type=Date)](https://star-history.com/#arco-design/arco-design-mobile&Date)


### PR DESCRIPTION
1.添加Less,TypeScript,React.js标签，让大家从文档一眼就看出技术栈是什么
2.添加npm的版本号标签和npm的下载量标签(标签中的变量和npm绑定,数值会自动改变)

合并理由如下：
1.由一个标签变成了两排六个标签，原来的license标签不再孤单，而且也好看一些
2.可以动态地看到npm的版本号和月下载量,可视化了arco-design的发展，也许看到是新起的，大家会更加踊跃地提出pr