### PR TITLE
fix: `Tabs` limit max scroll distance close

### DIFF
--- a/packages/arcodesign/components/tabs/tab-pane.tsx
+++ b/packages/arcodesign/components/tabs/tab-pane.tsx
@@ -218,12 +218,20 @@ const TabPane = forwardRef((props: TabPaneProps, ref: Ref<TabPaneRef>) => {
         const scrollTop = isGlobal
             ? Math.max(document.documentElement[scrollAttr], document.body[scrollAttr])
             : scrollEle[scrollAttr];
+        const scrollSizeAttr = scrollVertical ? 'scrollHeight' : 'scrollWidth';
+        const sizeAttr = scrollVertical ? 'offsetHeight' : 'offsetWidth';
+        const maxTopDis = isGlobal
+            ? document.body[scrollSizeAttr] -
+                scrollTop -
+                (scrollVertical ? window.innerHeight : window.innerWidth)
+            : scrollEle[scrollSizeAttr] - scrollTop - scrollEle[sizeAttr];
+        const normalizedTopDis = Math.min(maxTopDis, topDis);
         clearTimeout(timerRef.current);
         autoScrollingRef.current = true;
         const duration = rightNow ? 0 : transitionDuration || 0;
         scrollWithAnimation(
             scrollTop,
-            scrollTop + topDis,
+            scrollTop + normalizedTopDis,
             top => {
                 if (isGlobal) {
                     document.documentElement[scrollAttr] = top;

--- a/packages/arcodesign/components/tabs/tab-pane.tsx
+++ b/packages/arcodesign/components/tabs/tab-pane.tsx
@@ -221,7 +221,7 @@ const TabPane = forwardRef((props: TabPaneProps, ref: Ref<TabPaneRef>) => {
         const scrollSizeAttr = scrollVertical ? 'scrollHeight' : 'scrollWidth';
         const sizeAttr = scrollVertical ? 'offsetHeight' : 'offsetWidth';
         const maxTopDis = isGlobal
-            ? document.body[scrollSizeAttr] -
+            ? Math.max(document.documentElement[scrollSizeAttr], document.body[scrollSizeAttr]) -
                 scrollTop -
                 (scrollVertical ? window.innerHeight : window.innerWidth)
             : scrollEle[scrollSizeAttr] - scrollTop - scrollEle[sizeAttr];


### PR DESCRIPTION
通过限制最大的滚动距离来修复 #36，本地测试 work

iOS 的 scrollTop 没有按照[规范](https://drafts.csswg.org/cssom-view/#dom-window-scroll:~:text=If%20the%20viewport%20has%20downward,area%20height%20%2D%20viewport%20height)限制最大值，赋值超出范围会实时生效，影响 Sticky 的判断，测试 iOS 13 - 15 均有此问题，因此在 js 层面限制最大滚动距离 🤣