### PR TITLE
fix: `NavBar` fix warning in nextjs ssr

### DIFF
--- a/packages/arcodesign/components/nav-bar/index.tsx
+++ b/packages/arcodesign/components/nav-bar/index.tsx
@@ -254,7 +254,7 @@ const NavBar = forwardRef((props: NavBarProps, ref: Ref<NavBarRef>) => {
                         [`${prefixCls}-nav-bar-hide`]: scrollToggleHide,
                     })}
                     style={{
-                        paddingTop: fixed && statusBarHeight ? `${statusBarHeight}px` : '',
+                        paddingTop: fixed && statusBarHeight ? `${statusBarHeight}px` : '0px',
                         ...(style || {}),
                         ...(relBackground ? { background: relBackground } : {}),
                     }}
@@ -267,7 +267,7 @@ const NavBar = forwardRef((props: NavBarProps, ref: Ref<NavBarRef>) => {
                             [`${prefixCls}-nav-bar-wrapper-border`]: hasBottomLine,
                         })}
                         style={{
-                            paddingTop: statusBarHeight ? `${statusBarHeight}px` : '',
+                            paddingTop: statusBarHeight ? `${statusBarHeight}px` : '0px',
                             ...customStyle,
                         }}
                     >


### PR DESCRIPTION
我现在使用 NextJs 13 版本配置了 Arco-Design-react，在使用 NavBar 的时候提示了我 “op `style` did not match. Server: "null" Client: "padding-top:"” 的 warning，我发现在 Next.js 中，在服务端使用 createElement 生成 React Element 时，如果 style 属性的值为空字符串或 undefined，它会被替换成 null，原因是为了将其与行内样式混淆的情况区分开来，所以当 paddingTop 为空值时，我们最好默认它为 “0px”。
![WechatIMG137](https://user-images.githubusercontent.com/38753276/236619340-e4d21b24-c8f8-4ea6-b7ef-6a8a6cf5b009.png)
