### PR TITLE
site: fix li element overflow

### DIFF
--- a/sites/pc/entry/index.less
+++ b/sites/pc/entry/index.less
@@ -77,7 +77,6 @@
 
         li {
             margin-bottom: 12px;
-        
         }
 
         .demo-code-content {

--- a/sites/pc/entry/index.less
+++ b/sites/pc/entry/index.less
@@ -77,6 +77,7 @@
 
         li {
             margin-bottom: 12px;
+        
         }
 
         .demo-code-content {

--- a/sites/pc/entry/layout/index.less
+++ b/sites/pc/entry/layout/index.less
@@ -90,7 +90,8 @@ body {
             padding-left: 20px;
             li {
                 font-weight: 400;
-                height: auto;// 修改了height属性 
+                white-space: nowrap;
+                overflow: hidden;
                 line-height: 22px;
                 color: #424E66;
                 line-height: 2;

--- a/sites/pc/entry/layout/index.less
+++ b/sites/pc/entry/layout/index.less
@@ -90,7 +90,7 @@ body {
             padding-left: 20px;
             li {
                 font-weight: 400;
-                height: 22px;
+                height: auto;// 修改了height属性 
                 line-height: 22px;
                 color: #424E66;
                 line-height: 2;

--- a/sites/pc/entry/layout/index.less
+++ b/sites/pc/entry/layout/index.less
@@ -90,8 +90,6 @@ body {
             padding-left: 20px;
             li {
                 font-weight: 400;
-                white-space: nowrap;
-                overflow: hidden;
                 line-height: 22px;
                 color: #424E66;
                 line-height: 2;


### PR DESCRIPTION
[bugfix] 修复了 站点 mobile/react/arco-design/pc/#/doc/changelog 中li元素因换行导致的样式重叠问题