### PR TITLE
fix: `ImagePreview` refresh problem when onload of multiple pictures is triggered at the same time

### DIFF
--- a/packages/arcodesign/components/image-preview/index.tsx
+++ b/packages/arcodesign/components/image-preview/index.tsx
@@ -852,12 +852,14 @@ const ImagePreview = forwardRef((props: ImagePreviewProps, ref: Ref<ImagePreview
      * @en Change specified image status
      */
     function setImagesStatusByIndex(index: number, data: PreviewImageStatus) {
-        const newStatus = imagesStatusRef.current.slice();
-        newStatus[index] = {
-            ...(newStatus[index] || {}),
-            ...data,
-        };
-        setImagesStatus(newStatus);
+        setImagesStatus(current => {
+            const newStatus = current.slice();
+            newStatus[index] = {
+                ...(newStatus[index] || {}),
+                ...data,
+            };
+            return newStatus;
+        });
     }
 
     /**


### PR DESCRIPTION
问题描述：多张图片组件预览时，第一次打开黑屏，图片不显示
问题分析：
setImagesStatusByIndex  setImagesStatus
如果两张图片的onload事件同时到达，此时render没有来得刷新，会出现在一次render期间
setImagesStatus被调用两次，
第一次刷新时根据 imagesStatusRef.current 来计算
setImagesStatus 之后imagesStatusRef.current值没有立即改变
第二次刷新时也根据 imagesStatusRef.current 来计算
覆盖了第一次刷新的结果，导致第一张图片的loaded状态一直为false
