### PR TITLE
fix: `Tabs` trigger "onChange" before distance is set to 0

### DIFF
--- a/packages/arcodesign/components/tabs/index.tsx
+++ b/packages/arcodesign/components/tabs/index.tsx
@@ -404,10 +404,10 @@ const Tabs = forwardRef((props: TabsProps, ref: Ref<TabsRef>) => {
         changeFromRef.current = changeFrom || '';
         setCellTrans(true);
         setInnerIndex(newIndex);
-        setDistance(0);
         if (newIndex !== activeIndexRef.current) {
             onChange && onChange(tabs[newIndex], newIndex, changeFrom);
         }
+        setDistance(0);
     }
 
     return (


### PR DESCRIPTION
修复受控模式下切换 tab 时回弹动效问题