### PR TITLE
fix: `Ellipsis` use ellipsisValueRef to reduce reflow

### DIFF
--- a/packages/arcodesign/components/ellipsis/components/js-ellipsis.tsx
+++ b/packages/arcodesign/components/ellipsis/components/js-ellipsis.tsx
@@ -24,6 +24,8 @@ const JsEllipsis = forwardRef((props: JsEllipsisProps, ref: Ref<JsEllipsisRef>) 
     const domRef = useRef<HTMLDivElement>(null);
     const textRef = useRef<HTMLSpanElement>(null);
     const ellipsisRef = useRef<HTMLSpanElement>(null);
+    const ellipsisValueRef = useRef(ellipsis);
+    ellipsisValueRef.current = ellipsis;
 
     const lineHeightRef = useRef(0);
     const setCurLineHeight = useCallback(() => {
@@ -132,7 +134,7 @@ const JsEllipsis = forwardRef((props: JsEllipsisProps, ref: Ref<JsEllipsisRef>) 
         } else {
             textRef.current.innerText = text;
         }
-        if (!ellipsis) {
+        if (!ellipsisValueRef.current) {
             return;
         }
         textRef.current.classList.remove(`${prefixCls}-js-content-text-pre`);


### PR DESCRIPTION
在一个有展开收起的例子中。比如
```tsx
import { Ellipsis } from '@arco-design/mobile-react';

export default function EllipsisDemo() {
    const text =
        `This wasn't the first time ''natural'' sounds had been used in musical compositions; that sort of thing had been going on at least as far back as the 19th century, and the surrealists and futurists of the 1920s and 1930s were way into this kind of thing.`;
    const [ellipsis, setEllipsis] = React.useState(true);
    const collapseNode = <span className="demo-link">Collapse</span>;

    return (
        <Ellipsis
            ellipsis={ellipsis}
            text={text}
            maxLine={2}
            ellipsisNode={
                <span>
                    ...<span className="demo-link">Expand</span>
                </span>
            }
            collapseNode={collapseNode}
            reflowOnResize={true}
            onEllipsisNodeClick={() => {
                setEllipsis(false);
            }}
            onCollapseNodeClick={() => {
                setEllipsis(true);
            }}
        />
    );
}
```

点击展开节点执行 `setEllipsis(false);` 会设置ellipsis属性值为false。

这个时候在组件中，由于
https://github.com/arco-design/arco-design-mobile/blob/main/packages/arcodesign/components/ellipsis/components/js-ellipsis.tsx#L217-L222

```tsx
{!ellipsis && collapseNode && (
                <span className={`${prefixCls}-js-content-collapse`} onClick={onCollapseNodeClick}>
                    {collapseNode}
                </span>
 )}
```
这段代码，会在ellipsis变化的时候触发 `resize` 事件。

https://github.com/arco-design/arco-design-mobile/blob/main/packages/arcodesign/components/ellipsis/components/js-ellipsis.tsx#L163-L177

但其实这个时候，`useEffect`还没有重新执行，所以resize事件触发执行 `reflow`的时候，拿到的ellipsis是旧值为true，进行了不必要的二分查找计算。

使用ref来替换可以在reflow的时候拿到最新的值，从而避免这部分计算。

