### PR TITLE
fix: fix `useMountedState` in `hooks.ts` not correct init leavingRef in StrictMode.

### DIFF
--- a/packages/arcodesign/components/_helpers/hooks.ts
+++ b/packages/arcodesign/components/_helpers/hooks.ts
@@ -63,12 +63,12 @@ export function useMountedState<S>(initialState: S | (() => S)) {
         }
         setState(value);
     }, []);
-    useEffect(
-        () => () => {
+    useEffect(() => {
+        leavingRef.current = false;
+        return () => {
             leavingRef.current = true;
-        },
-        [],
-    );
+        };
+    }, []);
     const result: [S, typeof setState] = [state, setValidState];
     return result;
 }

--- a/packages/arcodesign/components/_helpers/hooks.ts
+++ b/packages/arcodesign/components/_helpers/hooks.ts
@@ -64,6 +64,7 @@ export function useMountedState<S>(initialState: S | (() => S)) {
         setState(value);
     }, []);
     useEffect(() => {
+        // see: https://github.com/arco-design/arco-design-mobile/pull/292
         leavingRef.current = false;
         return () => {
             leavingRef.current = true;


### PR DESCRIPTION
# Overview
this pr is about fix `hooks.ts` `useMountedState` not working correctly in React 18 with StrictMode.
StrictMode will render component twice,  but in `useMountedState` do not have code to re-init `leavingRef` when mounted again.

# Reference: 
- [aHooks - useUnmountedRef](https://github.com/alibaba/hooks/blob/master/packages/hooks/src/useUnmountedRef/index.tsx)
- [aHooks - useSafeState](https://github.com/alibaba/hooks/blob/master/packages/hooks/src/useSafeState/index.ts)


# Case
when i using `Picker` component, its data will not correctly updated after select `PickerCell` items.

# Issue
related #291

# Effected Component
- `image`
- `picker-view`
- `popover`