### PR TITLE
feat: Add workflow for PR preview deployment

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -33,7 +33,7 @@ jobs:
             - name: Merge output directories
               run: |
                   mkdir merged_output
-                  cp -R output/* merged_output/
+                  cp -R output/page/* merged_output/
                   cp -R output_resource/* merged_output/
 
             - name: Install Surge

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -108,8 +108,8 @@ jobs:
                       const deployMinutes = Math.floor(process.env.DEPLOY_DURATION / 60);
                       const deploySeconds = process.env.DEPLOY_DURATION % 60;
 
-                      const message = `## ✨ **PR Preview Link**: [${url}](${url})\n` +
-                                      `⏱ **Build Time**: ${buildMinutes}m ${buildSeconds}s\n` +
+                      const message = `## ✨ **PR Preview Link**: [${url}](${url})  \n` +
+                                      `⏱ **Build Time**: ${buildMinutes}m ${buildSeconds}s  \n` +
                                       `🚀 **Deploy Time**: ${deployMinutes}m ${deploySeconds}s`;
 
                       // 获取所有评论

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -51,7 +51,7 @@ jobs:
                   mv output/page/pc/* merged_output/mobile/react/arco-design/pc/
                   mv output/page/mobile/* merged_output/mobile/react/arco-design/mobile/
                   # 创建重定向 HTML 文件
-                  echo '<html><head><meta http-equiv="refresh" content="0; url=/mobile/react/" /></head><body></body></html>' > merged_output/index.html
+                  echo '<html><head><meta http-equiv="refresh" content="0; url=/mobile/react/arco-design/pc/" /></head><body></body></html>' > merged_output/index.html
 
             - name: Install Surge
               run: npm install --global surge

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -10,131 +10,24 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - name: Checkout code
-              uses: actions/checkout@v2
-
             - name: Set ARCO_SITE_DOMAIN
               run: echo "ARCO_SITE_DOMAIN=preview-${{ github.event.number }}-arco-design-mobile.surge.sh" >> $GITHUB_ENV
 
-            - name: Set up Node.js
-              uses: actions/setup-node@v2
+            - name: Find Comment
+              uses: peter-evans/find-comment@v2
+              id: fc
               with:
-                  node-version: '16'
-
-            - name: Start Build Timer
-              id: build_start
-              run: echo "BUILD_START=$(date +%s)" >> $GITHUB_ENV
-
-            - name: Install dependencies
-              run: npm install
-              env:
-                  ARCO_SITE_DOMAIN: ${{ env.ARCO_SITE_DOMAIN }}
-
-            - name: Build site:home
-              run: npm run site:home
-              env:
-                  ARCO_SITE_DOMAIN: ${{ env.ARCO_SITE_DOMAIN }}
-
-            - name: Build site:pc
-              run: npm run site:pc
-              env:
-                  ARCO_SITE_DOMAIN: ${{ env.ARCO_SITE_DOMAIN }}
-
-            - name: Build site:mobile
-              run: npm run site:mobile
-              env:
-                  ARCO_SITE_DOMAIN: ${{ env.ARCO_SITE_DOMAIN }}
-
-            - name: End Build Timer
-              id: build_end
-              run: echo "BUILD_END=$(date +%s)" >> $GITHUB_ENV
-
-            - name: Calculate Build Time
-              id: build_time
-              run: |
-                  BUILD_DURATION=$((BUILD_END - BUILD_START))
-                  echo "BUILD_DURATION=${BUILD_DURATION}" >> $GITHUB_ENV
-
-            - name: Merge output directories
-              run: |
-                  # 合并文件
-                  cp -R output_resource/* output/page/
-                  # 创建目标目录
-                  mkdir -p merged_output/mobile/react/arco-design/pc
-                  mkdir -p merged_output/mobile/react/arco-design/mobile
-                  # 移动目录内容
-                  mv output/page/home/* merged_output/mobile/react/
-                  mv output/page/pc/* merged_output/mobile/react/arco-design/pc/
-                  mv output/page/mobile/* merged_output/mobile/react/arco-design/mobile/
-                  # 创建重定向 HTML 文件
-                  echo '<html><head><meta http-equiv="refresh" content="0; url=/mobile/react/" /></head><body></body></html>' > merged_output/index.html
-
-            - name: Install Surge
-              run: npm install --global surge
-
-            - name: Start Deploy Timer
-              id: deploy_start
-              run: echo "DEPLOY_START=$(date +%s)" >> $GITHUB_ENV
-
-            - name: Deploy to Surge
-              env:
-                  SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
-                  ARCO_SITE_DOMAIN: ${{ env.ARCO_SITE_DOMAIN }}
-              run: |
-                  surge ./merged_output ${{ env.ARCO_SITE_DOMAIN }} --token $SURGE_TOKEN
-
-            - name: End Deploy Timer
-              id: deploy_end
-              run: echo "DEPLOY_END=$(date +%s)" >> $GITHUB_ENV
-
-            - name: Calculate Deploy Time
-              id: deploy_time
-              run: |
-                  DEPLOY_DURATION=$((DEPLOY_END - DEPLOY_START))
-                  echo "DEPLOY_DURATION=${DEPLOY_DURATION}" >> $GITHUB_ENV
+                  issue-number: ${{ github.event.pull_request.number }}
+                  comment-author: 'github-actions[bot]'
+                  body-includes: PR Preview Link
 
             - name: Comment PR with Preview Link
-              uses: actions/github-script@v6
+              uses: peter-evans/create-or-update-comment@v2
               env:
                   ARCO_SITE_DOMAIN: ${{ env.ARCO_SITE_DOMAIN }}
-                  BUILD_DURATION: ${{ env.BUILD_DURATION }}
-                  DEPLOY_DURATION: ${{ env.DEPLOY_DURATION }}
               with:
-                  script: |
-                      const url = `https://${process.env.ARCO_SITE_DOMAIN}`;
-
-                      const buildMinutes = Math.floor(process.env.BUILD_DURATION / 60);
-                      const buildSeconds = process.env.BUILD_DURATION % 60;
-                      const deployMinutes = Math.floor(process.env.DEPLOY_DURATION / 60);
-                      const deploySeconds = process.env.DEPLOY_DURATION % 60;
-
-                      const message = `## ✨ **PR Preview Link**: [${url}](${url})  \n` +
-                                      `⏱ **Build Time**: ${buildMinutes}m ${buildSeconds}s  \n` +
-                                      `🚀 **Deploy Time**: ${deployMinutes}m ${deploySeconds}s`;
-
-                      // 获取所有评论
-                      const { data: comments } = await github.rest.issues.listComments({
-                          issue_number: context.issue.number,
-                          owner: context.repo.owner,
-                          repo: context.repo.repo,
-                      });
-
-                      // 查找现有的预览链接评论
-                      const existingComment = comments.find(comment => comment.body.startsWith('## ✨ **PR Preview Link**'));
-
-                      if (existingComment) {
-                          // 更新现有评论
-                          await github.rest.issues.updateComment({
-                              owner: context.repo.owner,
-                              repo: context.repo.repo,
-                              comment_id: existingComment.id,
-                              body: message.trim(),
-                          });
-                      } else {
-                          // 创建新评论
-                          await github.rest.issues.createComment({
-                              issue_number: context.issue.number,
-                              owner: context.repo.owner,
-                              repo: context.repo.repo,
-                              body: message.trim(),
-                          });
+                  issue-number: ${{ github.event.pull_request.number }}
+                  comment-id: ${{ steps.fc.outputs.comment-id }}
+                  body: |
+                      ## ✨ **PR Preview Link**: [https://${{ env.ARCO_SITE_DOMAIN }}](https://${{ env.ARCO_SITE_DOMAIN }})  
+                      🕒 **Current Time**: ${{ github.run_started_at }}

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -21,6 +21,10 @@ jobs:
               with:
                   node-version: '16'
 
+            - name: Start Build Timer
+              id: build_start
+              run: echo "BUILD_START=$(date +%s)" >> $GITHUB_ENV
+
             - name: Install dependencies
               run: npm install
               env:
@@ -41,22 +45,36 @@ jobs:
               env:
                   ARCO_SITE_DOMAIN: ${{ env.ARCO_SITE_DOMAIN }}
 
+            - name: End Build Timer
+              id: build_end
+              run: echo "BUILD_END=$(date +%s)" >> $GITHUB_ENV
+
+            - name: Calculate Build Time
+              id: build_time
+              run: |
+                  BUILD_DURATION=$((BUILD_END - BUILD_START))
+                  echo "BUILD_DURATION=${BUILD_DURATION}" >> $GITHUB_ENV
+
             - name: Merge output directories
               run: |
-                  // 合并文件
+                  # 合并文件
                   cp -R output_resource/* output/page/
-                  // 创建目标目录
+                  # 创建目标目录
                   mkdir -p merged_output/mobile/react/arco-design/pc
                   mkdir -p merged_output/mobile/react/arco-design/mobile
-                  // 移动目录内容
+                  # 移动目录内容
                   mv output/page/home/* merged_output/mobile/react/
                   mv output/page/pc/* merged_output/mobile/react/arco-design/pc/
                   mv output/page/mobile/* merged_output/mobile/react/arco-design/mobile/
-                  // 创建重定向 HTML 文件
+                  # 创建重定向 HTML 文件
                   echo '<html><head><meta http-equiv="refresh" content="0; url=/mobile/react/" /></head><body></body></html>' > merged_output/index.html
 
             - name: Install Surge
               run: npm install --global surge
+
+            - name: Start Deploy Timer
+              id: deploy_start
+              run: echo "DEPLOY_START=$(date +%s)" >> $GITHUB_ENV
 
             - name: Deploy to Surge
               env:
@@ -65,17 +83,58 @@ jobs:
               run: |
                   surge ./merged_output ${{ env.ARCO_SITE_DOMAIN }} --token $SURGE_TOKEN
 
+            - name: End Deploy Timer
+              id: deploy_end
+              run: echo "DEPLOY_END=$(date +%s)" >> $GITHUB_ENV
+
+            - name: Calculate Deploy Time
+              id: deploy_time
+              run: |
+                  DEPLOY_DURATION=$((DEPLOY_END - DEPLOY_START))
+                  echo "DEPLOY_DURATION=${DEPLOY_DURATION}" >> $GITHUB_ENV
+
             - name: Comment PR with Preview Link
               uses: actions/github-script@v6
               env:
                   ARCO_SITE_DOMAIN: ${{ env.ARCO_SITE_DOMAIN }}
+                  BUILD_DURATION: ${{ env.BUILD_DURATION }}
+                  DEPLOY_DURATION: ${{ env.DEPLOY_DURATION }}
               with:
                   script: |
-                      const url = `https://${process.env.ARCO_SITE_DOMAIN}`
-                      const message = `✨ **PR Preview Link**: ${url} \n **PR 预览链接**: ${url}`
-                      github.rest.issues.createComment({
+                      const url = `https://${process.env.ARCO_SITE_DOMAIN}`;
+
+                      const buildMinutes = Math.floor(process.env.BUILD_DURATION / 60);
+                      const buildSeconds = process.env.BUILD_DURATION % 60;
+                      const deployMinutes = Math.floor(process.env.DEPLOY_DURATION / 60);
+                      const deploySeconds = process.env.DEPLOY_DURATION % 60;
+
+                      const message = `## ✨ **PR Preview Link**: [${url}](${url})\n` +
+                                      `⏱ **Build Time**: ${buildMinutes}m ${buildSeconds}s\n` +
+                                      `🚀 **Deploy Time**: ${deployMinutes}m ${deploySeconds}s`;
+
+                      // 获取所有评论
+                      const { data: comments } = await github.rest.issues.listComments({
                           issue_number: context.issue.number,
                           owner: context.repo.owner,
                           repo: context.repo.repo,
-                          body: message.trim()
-                      })
+                      });
+
+                      // 查找现有的预览链接评论
+                      const existingComment = comments.find(comment => comment.body.startsWith('## ✨ **PR Preview Link**'));
+
+                      if (existingComment) {
+                          // 更新现有评论
+                          await github.rest.issues.updateComment({
+                              owner: context.repo.owner,
+                              repo: context.repo.repo,
+                              comment_id: existingComment.id,
+                              body: message.trim(),
+                          });
+                      } else {
+                          // 创建新评论
+                          await github.rest.issues.createComment({
+                              issue_number: context.issue.number,
+                              owner: context.repo.owner,
+                              repo: context.repo.repo,
+                              body: message.trim(),
+                          });

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -52,6 +52,8 @@ jobs:
                   mv output/page/home/* merged_output/mobile/react/
                   mv output/page/pc/* merged_output/mobile/react/arco-design/pc/
                   mv output/page/mobile/* merged_output/mobile/react/arco-design/mobile/
+                  // 创建重定向 HTML 文件
+                  echo '<html><head><meta http-equiv="refresh" content="0; url=/mobile/react/" /></head><body></body></html>' > merged_output/index.html
 
             - name: Install Surge
               run: npm install --global surge

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -10,8 +10,58 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
+            - name: Checkout code
+              uses: actions/checkout@v2
+
+            - name: Set up Node.js
+              uses: actions/setup-node@v2
+              with:
+                  node-version: '16'
+
+            - name: Install dependencies
+              run: npm install
+
             - name: Set ARCO_SITE_DOMAIN
               run: echo "ARCO_SITE_DOMAIN=preview-${{ github.event.number }}-arco-design-mobile.surge.sh" >> $GITHUB_ENV
+
+            - name: Build site:home
+              run: npm run site:home
+              env:
+                  ARCO_SITE_DOMAIN: ${{ env.ARCO_SITE_DOMAIN }}
+
+            - name: Build site:pc
+              run: npm run site:pc
+              env:
+                  ARCO_SITE_DOMAIN: ${{ env.ARCO_SITE_DOMAIN }}
+
+            - name: Build site:mobile
+              run: npm run site:mobile
+              env:
+                  ARCO_SITE_DOMAIN: ${{ env.ARCO_SITE_DOMAIN }}
+
+            - name: Merge output directories
+              run: |
+                  # 合并文件
+                  cp -R output_resource/* output/page/
+                  # 创建目标目录
+                  mkdir -p merged_output/mobile/react/arco-design/pc
+                  mkdir -p merged_output/mobile/react/arco-design/mobile
+                  # 移动目录内容
+                  mv output/page/home/* merged_output/mobile/react/
+                  mv output/page/pc/* merged_output/mobile/react/arco-design/pc/
+                  mv output/page/mobile/* merged_output/mobile/react/arco-design/mobile/
+                  # 创建重定向 HTML 文件
+                  echo '<html><head><meta http-equiv="refresh" content="0; url=/mobile/react/" /></head><body></body></html>' > merged_output/index.html
+
+            - name: Install Surge
+              run: npm install --global surge
+
+            - name: Deploy to Surge
+              env:
+                  SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
+                  ARCO_SITE_DOMAIN: ${{ env.ARCO_SITE_DOMAIN }}
+              run: |
+                  surge ./merged_output ${{ env.ARCO_SITE_DOMAIN }} --token $SURGE_TOKEN
 
             - name: Find Comment
               uses: peter-evans/find-comment@v2
@@ -21,18 +71,13 @@ jobs:
                   comment-author: 'github-actions[bot]'
                   body-includes: PR Preview Link
 
-            - name: Get Current Time
-              run: echo "CURRENT_TIME=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> $GITHUB_ENV
-
             - name: Comment PR with Preview Link
               uses: peter-evans/create-or-update-comment@v2
               env:
                   ARCO_SITE_DOMAIN: ${{ env.ARCO_SITE_DOMAIN }}
-                  CURRENT_TIME: ${{ env.CURRENT_TIME }}
               with:
                   issue-number: ${{ github.event.pull_request.number }}
                   comment-id: ${{ steps.fc.outputs.comment-id }}
                   edit-mode: replace
                   body: |
-                      ✨ **PR Preview Link**: [https://${{ env.ARCO_SITE_DOMAIN }}](https://${{ env.ARCO_SITE_DOMAIN }})  
-                      🕒 **Current Time**: ${{ env.CURRENT_TIME }}
+                      ✨ **PR Preview Link**: [https://${{ env.ARCO_SITE_DOMAIN }}](https://${{ env.ARCO_SITE_DOMAIN }})

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -21,13 +21,17 @@ jobs:
                   comment-author: 'github-actions[bot]'
                   body-includes: PR Preview Link
 
+            - name: Get Current Time
+              run: echo "CURRENT_TIME=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> $GITHUB_ENV
+
             - name: Comment PR with Preview Link
               uses: peter-evans/create-or-update-comment@v2
               env:
                   ARCO_SITE_DOMAIN: ${{ env.ARCO_SITE_DOMAIN }}
+                  CURRENT_TIME: ${{ env.CURRENT_TIME }}
               with:
                   issue-number: ${{ github.event.pull_request.number }}
                   comment-id: ${{ steps.fc.outputs.comment-id }}
                   body: |
                       ## ✨ **PR Preview Link**: [https://${{ env.ARCO_SITE_DOMAIN }}](https://${{ env.ARCO_SITE_DOMAIN }})  
-                      🕒 **Current Time**: ${{ github.run_started_at }}
+                      🕒 **Current Time**: ${{ env.CURRENT_TIME }}

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,62 @@
+name: PR Preview
+
+on:
+    pull_request:
+        branches:
+            - main
+
+jobs:
+    build-and-deploy:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v2
+
+            - name: Set up Node.js
+              uses: actions/setup-node@v2
+              with:
+                  node-version: '16'
+
+            - name: Install dependencies
+              run: npm install
+
+            - name: Build site:home
+              run: npm run site:home
+
+            - name: Build site:pc
+              run: npm run site:pc
+
+            - name: Build site:mobile
+              run: npm run site:mobile
+
+            - name: Merge output directories
+              run: |
+                  mkdir merged_output
+                  cp -R output/* merged_output/
+                  cp -R output_resource/* merged_output/
+
+            - name: Install Surge
+              run: npm install --global surge
+
+            - name: Deploy to Surge
+              env:
+                  SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
+              run: |
+                  surge ./merged_output adm-pr-${{ github.event.number }}.surge.sh --token $SURGE_TOKEN
+
+            - name: Comment PR with Preview Link
+              uses: actions/github-script@v6
+              with:
+                  script: |
+                      const url = `https://adm-pr-${{ github.event.number }}.surge.sh`
+                      const message = `
+✨ **PR Preview Link**: ${url}
+✨ **PR 预览链接**: ${url}
+                      `
+                      github.rest.issues.createComment({
+                          issue_number: context.issue.number,
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          body: message.trim()
+                      })

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -50,10 +50,7 @@ jobs:
               with:
                   script: |
                       const url = `https://adm-pr-${{ github.event.number }}.surge.sh`
-                      const message = `
-✨ **PR Preview Link**: ${url}
-✨ **PR 预览链接**: ${url}
-                      `
+                      const message = `✨ **PR Preview Link**: ${url} \n **PR 预览链接**: ${url}`
                       github.rest.issues.createComment({
                           issue_number: context.issue.number,
                           owner: context.repo.owner,

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -32,6 +32,7 @@ jobs:
               with:
                   issue-number: ${{ github.event.pull_request.number }}
                   comment-id: ${{ steps.fc.outputs.comment-id }}
+                  edit-mode: replace
                   body: |
-                      ## ✨ **PR Preview Link**: [https://${{ env.ARCO_SITE_DOMAIN }}](https://${{ env.ARCO_SITE_DOMAIN }})  
+                      ✨ **PR Preview Link**: [https://${{ env.ARCO_SITE_DOMAIN }}](https://${{ env.ARCO_SITE_DOMAIN }})  
                       🕒 **Current Time**: ${{ env.CURRENT_TIME }}

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -13,6 +13,9 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@v2
 
+            - name: Set ARCO_SITE_DOMAIN
+              run: echo "ARCO_SITE_DOMAIN=preview-${{ github.event.number }}-arco-design-mobile.surge.sh" >> $GITHUB_ENV
+
             - name: Set up Node.js
               uses: actions/setup-node@v2
               with:
@@ -20,21 +23,33 @@ jobs:
 
             - name: Install dependencies
               run: npm install
+              env:
+                  ARCO_SITE_DOMAIN: ${{ env.ARCO_SITE_DOMAIN }}
 
             - name: Build site:home
               run: npm run site:home
+              env:
+                  ARCO_SITE_DOMAIN: ${{ env.ARCO_SITE_DOMAIN }}
 
             - name: Build site:pc
               run: npm run site:pc
+              env:
+                  ARCO_SITE_DOMAIN: ${{ env.ARCO_SITE_DOMAIN }}
 
             - name: Build site:mobile
               run: npm run site:mobile
+              env:
+                  ARCO_SITE_DOMAIN: ${{ env.ARCO_SITE_DOMAIN }}
 
             - name: Merge output directories
               run: |
                   mkdir merged_output
                   cp -R output/page/* merged_output/
                   cp -R output_resource/* merged_output/
+                  // 移动目录
+                  mv merged_output/home mobile/react/
+                  mv merged_output/pc mobile/react/arco-design/pc
+                  mv merged_output/mobile mobile/react/arco-design/mobile
 
             - name: Install Surge
               run: npm install --global surge
@@ -42,14 +57,17 @@ jobs:
             - name: Deploy to Surge
               env:
                   SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
+                  ARCO_SITE_DOMAIN: ${{ env.ARCO_SITE_DOMAIN }}
               run: |
-                  surge ./merged_output adm-pr-${{ github.event.number }}.surge.sh --token $SURGE_TOKEN
+                  surge ./merged_output ${{ env.ARCO_SITE_DOMAIN }} --token $SURGE_TOKEN
 
             - name: Comment PR with Preview Link
               uses: actions/github-script@v6
+              env:
+                  ARCO_SITE_DOMAIN: ${{ env.ARCO_SITE_DOMAIN }}
               with:
                   script: |
-                      const url = `https://adm-pr-${{ github.event.number }}.surge.sh`
+                      const url = `https://${process.env.ARCO_SITE_DOMAIN}`
                       const message = `✨ **PR Preview Link**: ${url} \n **PR 预览链接**: ${url}`
                       github.rest.issues.createComment({
                           issue_number: context.issue.number,

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -43,13 +43,15 @@ jobs:
 
             - name: Merge output directories
               run: |
-                  mkdir merged_output
-                  cp -R output/page/* merged_output/
-                  cp -R output_resource/* merged_output/
-                  // 移动目录
-                  mv merged_output/home mobile/react/
-                  mv merged_output/pc mobile/react/arco-design/pc
-                  mv merged_output/mobile mobile/react/arco-design/mobile
+                  // 合并文件
+                  cp -R output_resource/* output/page/
+                  // 创建目标目录
+                  mkdir -p merged_output/mobile/react/arco-design/pc
+                  mkdir -p merged_output/mobile/react/arco-design/mobile
+                  // 移动目录内容
+                  mv output/page/home/* merged_output/mobile/react/
+                  mv output/page/pc/* merged_output/mobile/react/arco-design/pc/
+                  mv output/page/mobile/* merged_output/mobile/react/arco-design/mobile/
 
             - name: Install Surge
               run: npm install --global surge

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ yarn.lock
 # package-lock.json
 output/
 output_resource/
+merged_output/
 .history
 *.func-info.json
 *.mixin-info.json

--- a/sites/home/inject/inject.config.js
+++ b/sites/home/inject/inject.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-    $siteDomain$: 'arco.design',
+    $siteDomain$: process.env.ARCO_SITE_DOMAIN ?? 'arco.design',
     $extraNavMenu$: '',
     $extraNavLink$: '',
     $footerFeedback$: '',

--- a/sites/pc/inject/inject.config.js
+++ b/sites/pc/inject/inject.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-    $siteDomain$: 'arco.design',
+    $siteDomain$: process.env.ARCO_SITE_DOMAIN ?? 'arco.design',
     $githubLink$: `{
         text: (
             <Tooltip content="Github" position="br">


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for generating and deploying a preview of the site when a pull request is made. 

此 PR 引入了一个新的 GitHub Actions 工作流程，用于在创建 PR 自动部署网站的预览，可以更方便的检查文档站和组件效果。


### GitHub Actions Workflow:

* [`.github/workflows/pr-preview.yml`](diffhunk://#diff-737d2247cd4b3b6578d2c5413b555a5ca90f6aaa32613770ffdc146900d0469bR1-R83): Added a new workflow named "PR Preview" that builds and deploys a preview of the site for pull requests to Surge and comments the preview link on the pull request.

### Site Configuration:

* [`sites/home/inject/inject.config.js`](diffhunk://#diff-065a3b3df2121fd63f642b07046b706d2c8d8e9bacb5a87e6307a476967decddL2-R2): Updated the `$siteDomain

 variable to use the `ARCO_SITE_DOMAIN` environment variable if it is set, otherwise defaulting to 'arco.design'.
* [`sites/pc/inject/inject.config.js`](diffhunk://#diff-a2f0c004aefb102eaed7ef6ba11f3cc545aa1eb89ef02c8af59575a0bcbf0a53L2-R2): Updated the `$siteDomain

 variable to use the `ARCO_SITE_DOMAIN` environment variable if it is set, otherwise defaulting to 'arco.design'.