### PR TITLE
feat: add dynamic theme usage

### DIFF
--- a/packages/arcodesign/components/context-provider/demo/index.md
+++ b/packages/arcodesign/components/context-provider/demo/index.md
@@ -24,3 +24,10 @@ export default function ContextProviderDemo() {
     </ContextProvider>);
 }
 ```
+
+```less
+.arco-cell-group {
+    .rem(border-radius, 8);
+    overflow: hidden;
+}
+```

--- a/packages/arcodesign/components/context-provider/demo/style/mobile.less
+++ b/packages/arcodesign/components/context-provider/demo/style/mobile.less
@@ -6,7 +6,5 @@
         padding: 0;
         background: transparent;
         .rem(margin, 0, 12);
-        .rem(border-radius, 8);
-        overflow: hidden;
     }
 }

--- a/packages/arcodesign/components/context-provider/demo/theme.md
+++ b/packages/arcodesign/components/context-provider/demo/theme.md
@@ -1,0 +1,47 @@
+## 动态主题 @en{Dynamic theme}
+
+#### 2
+
+如果需要动态主题切换，需要配置 less 选项`@use-css-vars: 1`以启用 css 变量（[详情见【快速上手 - 主题变量定制 & 动态切换】](/#/doc/readme)）。@en{If there is a need for dynamic theme switching, you need to configure the less option `@use-css-vars: 1` to enable css variable([For details, see [Quick Start - Theme variable customization & dynamic switching]](/#/doc/readme)).}
+
+请注意，由于 css variable 存在兼容性问题（<a href="https://caniuse.com/css-variables" target="_blank">查看兼容性</a>），请自行判断使用风险@en{Please note that due to the compatibility issues of css variables(<a href="https://caniuse.com/css-variables" target="_blank">Check compatibility</a>), please use it at your own risk.}
+
+```js
+import { ContextProvider, Button, Cell, Switch } from '@arco-design/mobile-react';
+
+export default function ContextProviderDemo() {
+    const [checked, setChecked] = React.useState(true);
+    const theme = React.useMemo(() => {
+        if (checked) {
+            return {
+                'button-primary-background': '#34C759',
+                'button-primary-clicked-background': '#00B42A',
+            };
+        }
+        return null;
+    }, [checked]);
+    return (
+        <ContextProvider theme={theme}>
+            <Cell label="Switch Theme" bordered={false}>
+                <Switch
+                    checked={checked}
+                    platform="ios"
+                    onChange={value => {
+                        setChecked(value);
+                    }}
+                />
+            </Cell>
+            <Button className="context-button">button</Button>
+        </ContextProvider>
+    );
+}
+```
+
+```less
+.arco-cell {
+    .rem(border-radius, 8);
+}
+.context-button {
+    margin-top: 10px;
+}
+```

--- a/scripts/sites/plugins/SiteGeneratePlugin/generate-components.js
+++ b/scripts/sites/plugins/SiteGeneratePlugin/generate-components.js
@@ -78,6 +78,7 @@ function generateComponents({
 
             // 渲染文档站 demo 内容部分
             const demoPath = path.join(compSrcPath, comp, 'demo');
+            const docPath = path.join(compPagePath, comp);
             const { demoSource = [], lessSources = {} } =
                 renderComponentsDemos({
                     demoSrcPath: demoPath,
@@ -124,7 +125,6 @@ function generateComponents({
                         </div>
                     );
                 }`);
-            const docPath = path.join(compPagePath, comp);
             fs.mkdirpSync(docPath);
             fs.writeFile(path.join(docPath, `index${tsxFileSuffix}.tsx`), entry, () => {
                 resolve(`>>> Write sites file finished: ${comp}`);


### PR DESCRIPTION
这个拉取请求包括对 `packages/arcodesign` 和 `scripts/sites/plugins/SiteGeneratePlugin` 目录的多个更改，重点是 CSS 调整、动态主题支持以及组件生成脚本的重构。最重要的更改包括添加动态主题支持、重构组件生成脚本，以及修改上下文提供器演示的 CSS 样式。

动态主题支持：

* [`packages/arcodesign/components/context-provider/demo/theme.md`](diffhunk://#diff-d2172cc2982530d0d8b752edb2c6d8c7c901c528c38c58066ad41c5292c222a7R1-R47)：添加了使用 CSS 变量进行动态主题切换的支持，并包含了主题切换的演示。

重构：

* [`scripts/sites/plugins/SiteGeneratePlugin/generate-components.js`](diffhunk://#diff-dcbf7e96901d7cb6ec6cb1180f57a6f99082a8c3a27c796d51855a8c1a2a8a36R81)：重构了 `generateComponents` 函数，将 `docPath` 变量的赋值移动到了函数的更前面部分。[[1]](diffhunk://#diff-dcbf7e96901d7cb6ec6cb1180f57a6f99082a8c3a27c796d51855a8c1a2a8a36R81) [[2]](diffhunk://#diff-dcbf7e96901d7cb6ec6cb1180f57a6f99082a8c3a27c796d51855a8c1a2a8a36L127)

CSS 调整：

* [`packages/arcodesign/components/context-provider/demo/index.md`](diffhunk://#diff-9a754d543669e9393ddf04ca223fb869d173379c9c259b7d2b5f2c6b18e6cebaR27-R33)：为演示添加了 `.arco-cell-group` 的新 CSS 样式。
* [`packages/arcodesign/components/context-provider/demo/style/mobile.less`](diffhunk://#diff-8253ab00dccb7831b02c1247bf0bea21db3aeb18813e3571ce29c0ffe72cc505L9-L10)：移除了 `.rem(border-radius, 8)` 和 `overflow: hidden` 的冗余 CSS 样式。