### PR TITLE
fix: keep empty value in renderLinkedContainer of `DatePicker`

### DIFF
--- a/packages/arcodesign/components/date-picker/index.tsx
+++ b/packages/arcodesign/components/date-picker/index.tsx
@@ -7,7 +7,7 @@ import React, {
     Ref,
     useImperativeHandle,
 } from 'react';
-import { cls, componentWrapper, formatDateNumber } from '@arco-design/mobile-utils';
+import { cls, componentWrapper, formatDateNumber, isEmptyValue } from '@arco-design/mobile-utils';
 import Picker, { PickerRef } from '../picker';
 import { PickerData, ValueType } from '../picker-view';
 import { ContextLayout } from '../context-provider';
@@ -292,7 +292,11 @@ const DatePicker = forwardRef((props: DatePickerProps, ref: Ref<DatePickerRef>) 
                     touchToStop={touchToStop}
                     renderLinkedContainer={
                         renderLinkedContainer
-                            ? () => renderLinkedContainer(currentTs, keyOptions)
+                            ? () =>
+                                  renderLinkedContainer(
+                                      isEmptyValue(props.currentTs) ? undefined : currentTs,
+                                      keyOptions,
+                                  )
                             : undefined
                     }
                 />

--- a/packages/arcodesign/components/date-picker/type.ts
+++ b/packages/arcodesign/components/date-picker/type.ts
@@ -125,5 +125,5 @@ export interface DatePickerProps
      * 将选择器的展现隐藏状态及选中值的展示与某个容器关联，传入后将同时渲染该容器和选择器组件，此时选择器组件的 visible 和 onHide 属性可不传，点击该容器会唤起选择器
      * @en Associate the hidden state of the picker and the display of the selected value with a container. After passing it in, the container and the picker component will be rendered at the same time. At this time, the visible and onHide attributes of the picker component are optional values. Clicking the container will evoke the picker
      */
-    renderLinkedContainer?: (currentTs: number, itemTypes: ItemType[]) => ReactNode;
+    renderLinkedContainer?: (currentTs: number | undefined, itemTypes: ItemType[]) => ReactNode;
 }


### PR DESCRIPTION
This pull request includes updates to the `DatePicker` component in the `packages/arcodesign` directory. The changes focus on handling empty values more gracefully in the `renderLinkedContainer` function.

Key changes:

* [`packages/arcodesign/components/date-picker/index.tsx`](diffhunk://#diff-10735aee4cdb6d455cc93497bf98499d7c6152137ddca7623f2d6b561babf68eL10-R10): Added `isEmptyValue` import from `@arco-design/mobile-utils` to check for empty values.
* [`packages/arcodesign/components/date-picker/index.tsx`](diffhunk://#diff-10735aee4cdb6d455cc93497bf98499d7c6152137ddca7623f2d6b561babf68eL295-R299): Updated `renderLinkedContainer` to handle cases where `props.currentTs` is empty by passing `undefined` instead of `currentTs`.
* [`packages/arcodesign/components/date-picker/type.ts`](diffhunk://#diff-1db88c88590c5c2e32ee65a11914fa39bb27300fc847244f3c1f9a5f291b1759L128-R128): Modified the `renderLinkedContainer` function signature to accept `currentTs` as `number | undefined` instead of just `number`.