### PR TITLE
fix: add harmony system detection support

### DIFF
--- a/packages/arcodesign/components/_helpers/hooks.ts
+++ b/packages/arcodesign/components/_helpers/hooks.ts
@@ -5,6 +5,7 @@
  */
 import React, { useState, useRef, useEffect, useCallback, useContext } from 'react';
 import { getSystem, scrollWithAnimation, safeGetComputedStyle } from '@arco-design/mobile-utils';
+import type { SystemOptions } from '@arco-design/mobile-utils/utils';
 import { GlobalContext } from '../context-provider';
 import { BezierType } from '../progress';
 
@@ -217,24 +218,30 @@ export function useLatestRef<T>(variable: T) {
     }, [variable]);
     return variableRef;
 }
-
 /**
  * 从navigator.userAgent中获取当前操作系统，如果无法获取ua，则从ContextProvider传入的system中获取值
  * @desc {en} Get the current operating system from navigator.userAgent, if ua cannot be obtained, get the value from the system passed in by ContextProvider
- * @returns system 操作系统，"" | "pc" | "android" | "ios"
+ * @param options 配置选项
+ * @param {en} options  Configuration options
+ * @param options.detectHarmony 是否识别鸿蒙系统，默认为 false，鸿蒙系统会被识别为 android
+ * @param {en} options.detectHarmony Whether to detect HarmonyOS separately, default is false, HarmonyOS will be recognized as android
+ * @returns 返回当前设备的操作系统，可能的值包括 'android'、'ios'、'harmony' 或 'pc'，如果无法获取，则返回空字符串
+ * @returns {en} Returns the operating system of the current device, possible values are 'android', 'ios', 'harmony', or 'pc'. Returns an empty string if it cannot be obtained
  * @example
  * ```
  * import { useSystem } from '@arco-design/mobile-react/esm/_helpers/hooks';
  *
  * const system = useSystem();
+ * // Or with options
+ * const systemWithHarmony = useSystem({ detectHarmony: true });
  * ```
  */
-export function useSystem() {
+export function useSystem(options: SystemOptions = { detectHarmony: false }) {
     const { system: currentSystem } = useContext(GlobalContext);
-    const [system, setSystem] = useState(() => currentSystem || getSystem());
+    const [system, setSystem] = useState(() => currentSystem || getSystem(options));
     useEffect(() => {
-        setSystem(currentSystem || getSystem());
-    }, [currentSystem]);
+        setSystem(currentSystem || getSystem(options));
+    }, [currentSystem, options]);
     return system;
 }
 

--- a/packages/arcodesign/components/_helpers/hooks.ts
+++ b/packages/arcodesign/components/_helpers/hooks.ts
@@ -236,7 +236,7 @@ export function useLatestRef<T>(variable: T) {
  * const systemWithHarmony = useSystem({ detectHarmony: true });
  * ```
  */
-export function useSystem(options: SystemOptions = { detectHarmony: false }) {
+export function useSystem(options: SystemOptions = {}) {
     const { system: currentSystem } = useContext(GlobalContext);
     const [system, setSystem] = useState(() => currentSystem || getSystem(options));
     useEffect(() => {

--- a/packages/arcodesign/components/_helpers/hooks.ts
+++ b/packages/arcodesign/components/_helpers/hooks.ts
@@ -236,7 +236,7 @@ export function useLatestRef<T>(variable: T) {
  * const systemWithHarmony = useSystem({ detectHarmony: true });
  * ```
  */
-export function useSystem(options: SystemOptions = {}) {
+export function useSystem(options?: SystemOptions) {
     const { system: currentSystem } = useContext(GlobalContext);
     const [system, setSystem] = useState(() => currentSystem || getSystem(options));
     useEffect(() => {

--- a/packages/arcodesign/components/_helpers/hooks.ts
+++ b/packages/arcodesign/components/_helpers/hooks.ts
@@ -5,7 +5,7 @@
  */
 import React, { useState, useRef, useEffect, useCallback, useContext } from 'react';
 import { getSystem, scrollWithAnimation, safeGetComputedStyle } from '@arco-design/mobile-utils';
-import type { SystemOptions } from '@arco-design/mobile-utils/utils';
+import type { SystemOptions } from '@arco-design/mobile-utils';
 import { GlobalContext } from '../context-provider';
 import { BezierType } from '../progress';
 

--- a/packages/common-widgets/utils/browser.ts
+++ b/packages/common-widgets/utils/browser.ts
@@ -39,12 +39,12 @@ export interface SystemOptions {
  * ```
  */
 
-export function getSystem(options: SystemOptions = { detectHarmony: false }) {
+export function getSystem(options: SystemOptions = {}) {
     try {
         const u = navigator.userAgent;
         // Do not modify the Harmony OS ua judgment rule, please refer to the official documentation: https://developer.huawei.com/consumer/cn/doc/harmonyos-guides/web-default-useragent
         if (/OpenHarmony/i.test(u)) {
-            return options.detectHarmony ? 'harmony' : 'android';
+            return options?.detectHarmony ? 'harmony' : 'android';
         }
         // Please do not ignore the case of the first letter
         if (u.indexOf('Android') > -1 || u.indexOf('Linux') > -1) {

--- a/packages/common-widgets/utils/browser.ts
+++ b/packages/common-widgets/utils/browser.ts
@@ -1,12 +1,25 @@
+export interface SystemOptions {
+    /**
+     * 是否识别鸿蒙系统，默认为 false，鸿蒙系统会被识别为 Android
+     * @en Whether to detect HarmonyOS separately, default is false, HarmonyOS will be recognized as Android
+     */
+    detectHarmony: boolean;
+}
+
 /**
  * 获取当前设备的操作系统
  * @desc {en} Get the operating system of the current device
- * @returns {string} 返回当前设备的操作系统，可能的值包括 'android'、'ios' 或 'pc'，如果无法获取，则返回空字符串
- * @returns {string} {en} Returns the operating system of the current device, possible values are 'android', 'ios', or 'pc'. Returns an empty string if it cannot be obtained
+ * @param options 配置选项
+ * @param {en} options Configuration options
+ * @param options.detectHarmony 是否识别鸿蒙系统，默认为 false，鸿蒙系统会被识别为 android
+ * @param {en} options.detectHarmony Whether to detect HarmonyOS separately, default is false, HarmonyOS will be recognized as android
+ * @returns 返回当前设备的操作系统，可能的值包括 'android'、'ios'、'harmony' 或 'pc'，如果无法获取，则返回空字符串
+ * @returns {en} Returns the operating system of the current device, possible values are 'android', 'ios', 'harmony', or 'pc'. Returns an empty string if it cannot be obtained
  * @example
  * ```
  * import { getSystem } from '@arco-design/mobile-utils';
  *
+ * // Default behavior
  * const systemInfo = getSystem();
  * if (systemInfo === 'android') {
  *     console.log('You are using the Android operating system');
@@ -17,16 +30,29 @@
  * } else {
  *     console.log('Unable to detect your operating system');
  * }
+ *
+ * // With HarmonyOS detection enabled
+ * const systemInfoWithHarmony = getSystem({ detectHarmony: true });
+ * if (systemInfoWithHarmony === 'harmony') {
+ *     console.log('You are using HarmonyOS');
+ * }
  * ```
  */
-export function getSystem() {
+
+export function getSystem(options: SystemOptions = { detectHarmony: false }) {
     try {
         const u = navigator.userAgent;
-        const android = u.indexOf('Android') > -1 || u.indexOf('Linux') > -1;
-        const ios = u.match(/\(i[^;]+;( U;)? CPU.+Mac OS X/);
-        const pc = !android && !ios;
-        const system = android ? 'android' : 'ios';
-        return pc ? 'pc' : system;
+        if (/android|linux/i.test(u)) {
+            return 'android';
+        }
+        if (/harmonyos|openharmony/i.test(u)) {
+            return options.detectHarmony ? 'harmony' : 'android';
+        }
+        // ios 这个正则理论上可以优化，但是历史原因不太敢改，不确定会不会有副作用
+        if (/\(i[^;]+;( U;)? CPU.+Mac OS X/.test(u)) {
+            return 'ios';
+        }
+        return 'pc';
     } catch (e) {
         return '';
     }

--- a/packages/common-widgets/utils/browser.ts
+++ b/packages/common-widgets/utils/browser.ts
@@ -42,13 +42,13 @@ export interface SystemOptions {
 export function getSystem(options: SystemOptions = { detectHarmony: false }) {
     try {
         const u = navigator.userAgent;
-        if (/android|linux/i.test(u)) {
-            return 'android';
-        }
         if (/harmonyos|openharmony/i.test(u)) {
             return options.detectHarmony ? 'harmony' : 'android';
         }
-        // ios 这个正则理论上可以优化，但是历史原因不太敢改，不确定会不会有副作用
+        if (/android|linux/i.test(u)) {
+            return 'android';
+        }
+        // iOS 的正则理论上可以优化，但历史原因一直这样用，贸然修改可能会有不可预知的副作用
         if (/\(i[^;]+;( U;)? CPU.+Mac OS X/.test(u)) {
             return 'ios';
         }

--- a/packages/common-widgets/utils/browser.ts
+++ b/packages/common-widgets/utils/browser.ts
@@ -41,17 +41,15 @@ export interface SystemOptions {
 
 export function getSystem(options: SystemOptions = { detectHarmony: false }) {
     try {
-        // eslint-disable-next-line no-console
-        console.log('=====navigator.userAgent======', navigator.userAgent);
         const u = navigator.userAgent;
-        if (/harmonyos|openharmony/i.test(u)) {
+        // Do not modify the Harmony OS ua judgment rule, please refer to the official documentation: https://developer.huawei.com/consumer/cn/doc/harmonyos-guides/web-default-useragent
+        if (/OpenHarmony/i.test(u)) {
             return options.detectHarmony ? 'harmony' : 'android';
         }
-        if (/Android|Linux/.test(u)) {
+        // Please do not ignore the case of the first letter
+        if (u.indexOf('Android') > -1 || u.indexOf('Linux') > -1) {
             return 'android';
         }
-        // iOS 的正则理论上可以优化，但历史一直这样用，修改可能会导致不可预知的问题
-        // The regular expression for iOS can theoretically be optimized, but it has been used like this in history, and modifying it may cause unpredictable problems
         if (/\(i[^;]+;( U;)? CPU.+Mac OS X/.test(u)) {
             return 'ios';
         }

--- a/packages/common-widgets/utils/browser.ts
+++ b/packages/common-widgets/utils/browser.ts
@@ -41,14 +41,17 @@ export interface SystemOptions {
 
 export function getSystem(options: SystemOptions = { detectHarmony: false }) {
     try {
+        // eslint-disable-next-line no-console
+        console.log('=====navigator.userAgent======', navigator.userAgent);
         const u = navigator.userAgent;
         if (/harmonyos|openharmony/i.test(u)) {
             return options.detectHarmony ? 'harmony' : 'android';
         }
-        if (/android|linux/i.test(u)) {
+        if (/Android|Linux/.test(u)) {
             return 'android';
         }
-        // iOS 的正则理论上可以优化，但历史原因一直这样用，贸然修改可能会有不可预知的副作用
+        // iOS 的正则理论上可以优化，但历史一直这样用，修改可能会导致不可预知的问题
+        // The regular expression for iOS can theoretically be optimized, but it has been used like this in history, and modifying it may cause unpredictable problems
         if (/\(i[^;]+;( U;)? CPU.+Mac OS X/.test(u)) {
             return 'ios';
         }

--- a/packages/common-widgets/utils/browser.ts
+++ b/packages/common-widgets/utils/browser.ts
@@ -46,7 +46,7 @@ export function getSystem(options?: SystemOptions) {
         if (/OpenHarmony/i.test(u)) {
             return options?.detectHarmony ? 'harmony' : 'android';
         }
-        // Please do not ignore the case of the first letter
+        // Do not ignore the case of the first letter
         if (u.indexOf('Android') > -1 || u.indexOf('Linux') > -1) {
             return 'android';
         }

--- a/packages/common-widgets/utils/browser.ts
+++ b/packages/common-widgets/utils/browser.ts
@@ -47,7 +47,7 @@ export function getSystem(options?: SystemOptions) {
             return options?.detectHarmony ? 'harmony' : 'android';
         }
         // Do not ignore the case of the first letter
-        if (u.indexOf('Android') > -1 || u.indexOf('Linux') > -1) {
+        if (/Android|Linux/.test(u)) {
             return 'android';
         }
         if (/\(i[^;]+;( U;)? CPU.+Mac OS X/.test(u)) {

--- a/packages/common-widgets/utils/browser.ts
+++ b/packages/common-widgets/utils/browser.ts
@@ -3,7 +3,7 @@ export interface SystemOptions {
      * 是否识别鸿蒙系统，默认为 false，鸿蒙系统会被识别为 Android
      * @en Whether to detect HarmonyOS separately, default is false, HarmonyOS will be recognized as Android
      */
-    detectHarmony: boolean;
+    detectHarmony?: boolean;
 }
 
 /**

--- a/packages/common-widgets/utils/browser.ts
+++ b/packages/common-widgets/utils/browser.ts
@@ -39,7 +39,7 @@ export interface SystemOptions {
  * ```
  */
 
-export function getSystem(options: SystemOptions = {}) {
+export function getSystem(options?: SystemOptions) {
     try {
         const u = navigator.userAgent;
         // Do not modify the Harmony OS ua judgment rule, please refer to the official documentation: https://developer.huawei.com/consumer/cn/doc/harmonyos-guides/web-default-useragent

--- a/sites/pc/docOutput/function/browser.README.md
+++ b/sites/pc/docOutput/function/browser.README.md
@@ -12,6 +12,7 @@
 
 ```
 import { getSystem } from '@arco-design/mobile-utils';
+// Default behavior
 const systemInfo = getSystem();
 if (systemInfo === 'android') {
      console.log('You are using the Android operating system');
@@ -22,25 +23,37 @@ if (systemInfo === 'android') {
 } else {
      console.log('Unable to detect your operating system');
 }
+// With HarmonyOS detection enabled
+const systemInfoWithHarmony = getSystem({ detectHarmony: true });
+if (systemInfoWithHarmony === 'harmony') {
+     console.log('You are using HarmonyOS');
+}
 ```
 
 ## 类型
 
 ```
-() => string
+(options?: SystemOptions | undefined) => "harmony" | "android" | "ios" | "pc" | ""
 ```
 
 ## 源码
 
 ```
-function getSystem() {
+function getSystem(options?: SystemOptions) {
     try {
         const u = navigator.userAgent;
-        const android = u.indexOf('Android') > -1 || u.indexOf('Linux') > -1;
-        const ios = u.match(/\(i[^;]+;( U;)? CPU.+Mac OS X/);
-        const pc = !android && !ios;
-        const system = android ? 'android' : 'ios';
-        return pc ? 'pc' : system;
+        // Do not modify the Harmony OS ua judgment rule, please refer to the official documentation: https://developer.huawei.com/consumer/cn/doc/harmonyos-guides/web-default-useragent
+        if (/OpenHarmony/i.test(u)) {
+            return options?.detectHarmony ? 'harmony' : 'android';
+        }
+        // Do not ignore the case of the first letter
+        if (/Android|Linux/.test(u)) {
+            return 'android';
+        }
+        if (/\(i[^;]+;( U;)? CPU.+Mac OS X/.test(u)) {
+            return 'ios';
+        }
+        return 'pc';
     } catch (e) {
         return '';
     }
@@ -51,11 +64,19 @@ function getSystem() {
 
 > 输入
 
-无
+|参数|描述|类型|默认值|
+|----------|-------------|------|------|
+|options|配置选项|SystemOptions \| undefined|-|
 
 > 输出
 
-{string} 返回当前设备的操作系统，可能的值包括 'android'、'ios' 或 'pc'，如果无法获取，则返回空字符串
+返回当前设备的操作系统，可能的值包括 'android'、'ios'、'harmony' 或 'pc'，如果无法获取，则返回空字符串
+
+> SystemOptions
+
+|参数|描述|类型|
+|----------|-------------|------|
+|detectHarmony|是否识别鸿蒙系统，默认为 false，鸿蒙系统会被识别为 Android @en Whether to detect HarmonyOS separately, default is false, HarmonyOS will be recognized as Android|boolean|
 
 ------
 

--- a/sites/pc/docOutput/function/hooks/hooks.README.md
+++ b/sites/pc/docOutput/function/hooks/hooks.README.md
@@ -88,12 +88,13 @@ function useMountedState<S>(initialState: S | (() => S)) {
         }
         setState(value);
     }, []);
-    useEffect(
-        () => () => {
+    useEffect(() => {
+        // see: https://github.com/arco-design/arco-design-mobile/pull/292
+        leavingRef.current = false;
+        return () => {
             leavingRef.current = true;
-        },
-        [],
-    );
+        };
+    }, []);
     const result: [S, typeof setState] = [state, setValidState];
     return result;
 }
@@ -412,23 +413,25 @@ variableRef，变量的最新ref值
 ```
 import { useSystem } from '@arco-design/mobile-react/esm/_helpers/hooks';
 const system = useSystem();
+// Or with options
+const systemWithHarmony = useSystem({ detectHarmony: true });
 ```
 
 ## 类型
 
 ```
-() => "" | "pc" | "android" | "ios"
+(options?: SystemOptions | undefined) => "" | "pc" | "android" | "ios" | "harmony"
 ```
 
 ## 源码
 
 ```
-function useSystem() {
+function useSystem(options?: SystemOptions) {
     const { system: currentSystem } = useContext(GlobalContext);
-    const [system, setSystem] = useState(() => currentSystem || getSystem());
+    const [system, setSystem] = useState(() => currentSystem || getSystem(options));
     useEffect(() => {
-        setSystem(currentSystem || getSystem());
-    }, [currentSystem]);
+        setSystem(currentSystem || getSystem(options));
+    }, [currentSystem, options]);
     return system;
 }
 ```
@@ -437,11 +440,19 @@ function useSystem() {
 
 > 输入
 
-无
+|参数|描述|类型|默认值|
+|----------|-------------|------|------|
+|options|配置选项|SystemOptions \| undefined|-|
 
 > 输出
 
-system 操作系统，"" | "pc" | "android" | "ios"
+返回当前设备的操作系统，可能的值包括 'android'、'ios'、'harmony' 或 'pc'，如果无法获取，则返回空字符串
+
+> SystemOptions
+
+|参数|描述|类型|
+|----------|-------------|------|
+|detectHarmony|是否识别鸿蒙系统，默认为 false，鸿蒙系统会被识别为 Android @en Whether to detect HarmonyOS separately, default is false, HarmonyOS will be recognized as Android|boolean|
 
 ------
 


### PR DESCRIPTION
This pull request introduces several changes to improve the detection of the HarmonyOS operating system in the `arco-design` package. The most significant changes include updates to the `useSystem` hook and the `getSystem` utility function to support an optional configuration for detecting HarmonyOS.

Enhancements to OS detection:

* [`packages/arcodesign/components/_helpers/hooks.ts`](diffhunk://#diff-c09413cb5bf6a983e28de9e244bdf9efe4419b4f675e73d6b79e5015127fc9c7L220-R244): Added a new parameter `options` to the `useSystem` function, allowing the detection of HarmonyOS separately. Updated the function to use this parameter when determining the operating system.
* [`packages/common-widgets/utils/browser.ts`](diffhunk://#diff-10fbf67be2e0f5337cfbbd11fd61da958f6287a39ff3a3f2c6095888caa3f433R1-R22): Introduced a new `SystemOptions` interface and updated the `getSystem` function to accept this interface as an optional parameter. This allows the function to detect HarmonyOS separately based on the provided options. [[1]](diffhunk://#diff-10fbf67be2e0f5337cfbbd11fd61da958f6287a39ff3a3f2c6095888caa3f433R1-R22) [[2]](diffhunk://#diff-10fbf67be2e0f5337cfbbd11fd61da958f6287a39ff3a3f2c6095888caa3f433R33-R55)

Code organization and type improvements:

* [`packages/arcodesign/components/_helpers/hooks.ts`](diffhunk://#diff-c09413cb5bf6a983e28de9e244bdf9efe4419b4f675e73d6b79e5015127fc9c7R8): Imported the `SystemOptions` type from `@arco-design/mobile-utils/utils` to ensure type safety and consistency.