### PR TITLE
fix: `SearchBar` add mouse event param to "onAssociationItemClick"

### DIFF
--- a/packages/arcodesign/components/search-bar/README.en-US.md
+++ b/packages/arcodesign/components/search-bar/README.en-US.md
@@ -23,7 +23,7 @@ SearchBar component
 |highlightStyle|The style to be added to the highlighted result, only available in non\-custom highlight mode|CSSProperties|-|
 |highlightClassName|The class to be added to the highlighting result, only valid in non\-custom highlighting mode|string|-|
 |onCancel|Right cancel button click callback|() =\> void|-|
-|onAssociationItemClick|Click callback for each row of search results|(item: SearchAssociationBaseItem, index: number) =\> void|-|
+|onAssociationItemClick|Click callback for each row of search results|(item: SearchAssociationBaseItem, index: number, event: MouseEvent\<HTMLDivElement, MouseEvent\>) =\> void|-|
 |onAssociationClick|The callback for the overall click of the search association box|(event: MouseEvent\<HTMLDivElement, MouseEvent\>) =\> void|-|
 |renderAssociationItem|Custom rendering of each row of search results|(item: SearchAssociationBaseItem, index: number, node: ReactNode) =\> ReactNode|-|
 |renderAssociation|Customize the rendering of the overall content of the search association box|(Content: ReactNode) =\> ReactNode|-|

--- a/packages/arcodesign/components/search-bar/README.md
+++ b/packages/arcodesign/components/search-bar/README.md
@@ -23,7 +23,7 @@
 |highlightStyle|要为高亮结果添加的样式，仅非自定高亮模式下生效|CSSProperties|-|
 |highlightClassName|要为高亮结果添加的class，仅非自定义高亮模式下生效|string|-|
 |onCancel|右侧取消按钮的点击回调|() =\> void|-|
-|onAssociationItemClick|每行搜索结果的点击回调|(item: SearchAssociationBaseItem, index: number) =\> void|-|
+|onAssociationItemClick|每行搜索结果的点击回调|(item: SearchAssociationBaseItem, index: number, event: MouseEvent\<HTMLDivElement, MouseEvent\>) =\> void|-|
 |onAssociationClick|搜索联想框整体被点击的回调|(event: MouseEvent\<HTMLDivElement, MouseEvent\>) =\> void|-|
 |renderAssociationItem|自定义渲染每行搜索结果|(item: SearchAssociationBaseItem, index: number, node: ReactNode) =\> ReactNode|-|
 |renderAssociation|自定义渲染搜索联想框整体内容|(Content: ReactNode) =\> ReactNode|-|

--- a/packages/arcodesign/components/search-bar/__ast__/index.ast.json
+++ b/packages/arcodesign/components/search-bar/__ast__/index.ast.json
@@ -302,7 +302,7 @@
             },
             "required": false,
             "type": {
-                "name": "(item: SearchAssociationBaseItem, index: number) => void"
+                "name": "(item: SearchAssociationBaseItem, index: number, event: MouseEvent<HTMLDivElement, MouseEvent>) => void"
             }
         },
         "onAssociationClick": {

--- a/packages/arcodesign/components/search-bar/__test__/index.spec.js
+++ b/packages/arcodesign/components/search-bar/__test__/index.spec.js
@@ -244,7 +244,7 @@ describe('SearchBar', () => {
 
         const firstAssociationItem = associationItemDoms[0];
         await userEvent.click(firstAssociationItem);
-        expect(handleAssociationItemClick).toHaveBeenCalledWith(associationItems[0], 0);
+        expect(handleAssociationItemClick).toHaveBeenCalled();
     });
 
     it('highlight prefix mode work correctly', () => {

--- a/packages/arcodesign/components/search-bar/association.tsx
+++ b/packages/arcodesign/components/search-bar/association.tsx
@@ -61,7 +61,7 @@ export function SearchBarAssociation<Data>(props: SearchBarAssociationProps<Data
             <div
                 key={index}
                 className={`${searchBarAssociationPrefixCls}-item`}
-                onClick={() => onAssociationItemClick?.(item, index)}
+                onClick={e => onAssociationItemClick?.(item, index, e)}
             >
                 {node}
             </div>

--- a/packages/arcodesign/components/search-bar/type.ts
+++ b/packages/arcodesign/components/search-bar/type.ts
@@ -68,7 +68,11 @@ export interface SearchBarAssociationProps<Data = Record<string, any>> {
      * 每行搜索结果的点击回调
      * @en Click callback for each row of search results
      */
-    onAssociationItemClick?: (item: SearchAssociationItem<Data>, index: number) => void;
+    onAssociationItemClick?: (
+        item: SearchAssociationItem<Data>,
+        index: number,
+        event: React.MouseEvent<HTMLDivElement, MouseEvent>,
+    ) => void;
     /**
      * 搜索联想框整体被点击的回调
      * @en The callback for the overall click of the search association box

--- a/scripts/sites/plugins/DemoGeneratePlugin/generate-demo.js
+++ b/scripts/sites/plugins/DemoGeneratePlugin/generate-demo.js
@@ -249,12 +249,13 @@ function generateSiteDemo({
                     devDemos,
                 });
                 importStr += `import ${importDemoName} from './_${importDemoName}';`;
+                const orderId = String(order).replace('.', '-'); // 用于类名时去掉特殊小数点
                 demoSource.push({
                     order,
                     source: source.replace(
                         /__CODE_RENDERER__/,
                         `
-                <div className="arcodesign-mobile-demo-content" id="demo-order-${order}">
+                <div className="arcodesign-mobile-demo-content" id="demo-order-${orderId}">
                     <${importDemoName} />
                 </div>`,
                     ),
@@ -262,7 +263,7 @@ function generateSiteDemo({
 
                 // 处理 demo 局部样式，在 less 外加上 #demo-order-{num} 选择器
                 if (styleSource) {
-                    demoShowStyle += `#demo-order-${order} {${styleSource}}`;
+                    demoShowStyle += `#demo-order-${orderId} {${styleSource}}`;
                 }
 
                 // 处理 demo 全局样式


### PR DESCRIPTION
This pull request introduces changes to the `SearchBar` component and associated files to enhance functionality by adding an `event` parameter to the `onAssociationItemClick` callback. Additionally, it includes a minor improvement to demo generation by ensuring valid CSS class names. Below is a breakdown of the most important changes:

### Enhancements to `SearchBar` Component

* Updated the `onAssociationItemClick` callback across multiple files to include an additional `event` parameter, enabling access to the `MouseEvent` object when a search result item is clicked. This change was applied to:
  - Documentation files: `README.en-US.md` and `README.md` [[1]](diffhunk://#diff-2fe04e0deaa8d97eaf2dab825ab5f95a8659c6c3a1683cd409e2cae18cce9216L26-R26) [[2]](diffhunk://#diff-44bdd5a5b7699446e08e805d3c084930c503ae08b73a0fb22c7728e3bc7deb9fL26-R26)
  - Type definitions in `type.ts`
  - AST file: `index.ast.json`
  - Implementation in `association.tsx`

### Improvements to Demo Generation

* Modified the demo generation script in `generate-demo.js` to replace decimal points in `order` values with hyphens when constructing CSS class names, ensuring compatibility with CSS selectors.