### PR TITLE
fix: `Tabs` optimize updateLayout

### DIFF
--- a/packages/arcodesign/components/tabs/README.en-US.md
+++ b/packages/arcodesign/components/tabs/README.en-US.md
@@ -1,6 +1,6 @@
 ### Navigation
 
-# Tabs 
+# Tabs
 
 Used to let the user switch between different views. In order to optimize the rendering performance of the mobile terminal, if you need to replace the DOM, send a request to update data, etc., please do it in the `onAfterChange` instead of the `onChange` callback.
 
@@ -173,7 +173,7 @@ string | { [x: string]: any; title: ReactNode; }
 |scrollTo|Scroll the bar to the specified position, the tabs are scrolled on the x\-axis when the tabs are laid out up and down, and the y\-axis is scrolled when the tabs are laid out left and right|(position: number, rightNow?: boolean) =\> void|
 |scrollToCenter|Scroll the bar to bring the currently selected item to the middle of the screen|(rightNow?: boolean) =\> void|
 |setCaterpillarAnimate|Trigger caterpillar animation|(ratio?: number) =\> void|
-|resetUnderlineStyle|Recalculate underline style|() =\> void|
+|resetUnderlineStyle|Recalculate underline style (only recalculate position, if the tab cell DOM is changed manually, please call updateLayout)|() =\> void|
 |updateLayout|Force update tab\-cell|() =\> void|
 
 > TabPaneRef

--- a/packages/arcodesign/components/tabs/README.md
+++ b/packages/arcodesign/components/tabs/README.md
@@ -173,7 +173,7 @@ string | { [x: string]: any; title: ReactNode; }
 |scrollTo|滚动 bar 到指定位置，tabs 上下布局时是以 x 轴滚动，左右布局时以 y 轴滚动|(position: number, rightNow?: boolean) =\> void|
 |scrollToCenter|滚动 bar 使当前选中item到屏幕中间|(rightNow?: boolean) =\> void|
 |setCaterpillarAnimate|触发毛毛虫动画|(ratio?: number) =\> void|
-|resetUnderlineStyle|重新计算下划线样式|() =\> void|
+|resetUnderlineStyle|重新计算下划线样式（仅重算位置，如果 tab cell DOM 被人为改变，请调用 updateLayout）|() =\> void|
 |updateLayout|强制更新 tab\-cell|() =\> void|
 
 > TabPaneRef

--- a/packages/arcodesign/components/tabs/__ast__/index.ast.json
+++ b/packages/arcodesign/components/tabs/__ast__/index.ast.json
@@ -2459,15 +2459,15 @@
             "resetUnderlineStyle": {
                 "name": "resetUnderlineStyle",
                 "required": true,
-                "description": "重新计算下划线样式\n@en Recalculate underline style",
+                "description": "重新计算下划线样式（仅重算位置，如果 tab cell DOM 被人为改变，请调用 updateLayout）\n@en Recalculate underline style (only recalculate position, if the tab cell DOM is changed manually, please call updateLayout)",
                 "defaultValue": null,
                 "type": {
                     "name": "() => void"
                 },
                 "tags": {
-                    "en": "Recalculate underline style"
+                    "en": "Recalculate underline style (only recalculate position, if the tab cell DOM is changed manually, please call updateLayout)"
                 },
-                "descWithTags": "重新计算下划线样式"
+                "descWithTags": "重新计算下划线样式（仅重算位置，如果 tab cell DOM 被人为改变，请调用 updateLayout）"
             },
             "updateLayout": {
                 "name": "updateLayout",

--- a/packages/arcodesign/components/tabs/index.tsx
+++ b/packages/arcodesign/components/tabs/index.tsx
@@ -380,7 +380,7 @@ const Tabs = forwardRef((props: TabsProps, ref: Ref<TabsRef>) => {
 
     function updateLayout() {
         const { width, height } = getOffset(domRef.current);
-        cellRef.current && cellRef.current.resetUnderlineStyle();
+        cellRef.current && cellRef.current.updateLayout();
         setWrapWidth(width || domRef.current?.offsetWidth || 0);
         setWrapHeight(height || domRef.current?.offsetHeight || 0);
         paneRef.current && paneRef.current.setCurrentHeight();

--- a/packages/arcodesign/components/tabs/type.ts
+++ b/packages/arcodesign/components/tabs/type.ts
@@ -613,8 +613,8 @@ export interface TabCellRef {
      */
     setCaterpillarAnimate: (ratio?: number) => void;
     /**
-     * 重新计算下划线样式
-     * @en Recalculate underline style
+     * 重新计算下划线样式（仅重算位置，如果 tab cell DOM 被人为改变，请调用 updateLayout）
+     * @en Recalculate underline style (only recalculate position, if the tab cell DOM is changed manually, please call updateLayout)
      */
     resetUnderlineStyle: () => void;
     /**


### PR DESCRIPTION
This pull request updates the `resetUnderlineStyle` method across multiple files in the `tabs` component to clarify its behavior and ensure consistency. The method now explicitly states that it only recalculates the position of the underline style and advises calling `updateLayout` if the tab cell DOM is manually changed. Additionally, the implementation of `updateLayout` has been updated to call `updateLayout` on `cellRef` instead of `resetUnderlineStyle`.

### Documentation Updates:
* Updated the description of `resetUnderlineStyle` in `README.en-US.md` and `README.md` to clarify its behavior and include instructions for manual DOM changes. [[1]](diffhunk://#diff-d6199cd697edbca89ba7d47fd111eb68f62261ee6e20ad526d77ca6903b8c378L176-R176) [[2]](diffhunk://#diff-4ca80e81f9f987a7bf72fae0d8be57a56170148701db93eea6875027455f40e8L176-R176)
* Modified the `resetUnderlineStyle` description in `index.ast.json` to match the updated documentation, ensuring consistency across auto-generated metadata.

### Code Updates:
* Changed the implementation of `updateLayout` in `index.tsx` to call `updateLayout` on `cellRef` instead of `resetUnderlineStyle`, aligning with the updated method behavior.
* Updated the `resetUnderlineStyle` method's comment in `type.ts` to reflect the clarified behavior and provide guidance for handling manual DOM changes.