### PR TITLE
fix: `Popover` adjust edge when popover is too tall

### DIFF
--- a/packages/arcodesign/components/popover/hooks/usePosition.ts
+++ b/packages/arcodesign/components/popover/hooks/usePosition.ts
@@ -213,28 +213,47 @@ export const usePosition = (
         // 垂直方向安全距离调整
         // @en Vertical safety distance adjustment
         if (verticalAuto) {
-            const popoverTop =
-                childRect.bottom -
-                (newConfig.bottom && newConfig.height ? newConfig.bottom + newConfig.height : 0);
-            const popoverBottom =
-                childRect.top +
-                (newConfig.top && newConfig.height ? newConfig.top + newConfig.height : 0);
-
-            // 顶部安全距离不够，调整到底部
-            // @en The top safety distance is not enough, adjust to the bottom
-            if (directionState.indexOf('top') !== -1 && popoverTop < topOffset) {
+            const setToBottom = () => {
                 newConfig.top = verticalOffset + childRect.height;
                 newConfig.bottom = null;
                 onAdjustDirection('bottom');
-            } else if (
-                directionState.indexOf('bottom') !== -1 &&
-                popoverBottom + bottomOffset > window.innerHeight
-            ) {
-                // 底部安全距离不够，调整到顶部
-                // @en The bottom safety distance is not enough, adjust to the top
+            };
+            const setToTop = () => {
                 newConfig.top = null;
                 newConfig.bottom = verticalOffset + childRect.height;
                 onAdjustDirection('top');
+            };
+
+            // 判断上下空间是否都不足以展示气泡内容
+            // @en Determine whether there is insufficient space both above and below to display content
+            const isPopoverTooTall =
+                window.innerHeight - topOffset - bottomOffset <
+                2 * (newConfig.height || 0) + 2 * verticalOffset + childRect.height;
+            if (isPopoverTooTall) {
+                const spaceAbove = childRect.top;
+                const spaceBelow = window.innerHeight - childRect.bottom;
+                spaceAbove > spaceBelow ? setToTop() : setToBottom();
+            } else {
+                const popoverTop =
+                    childRect.bottom -
+                    (newConfig.bottom && newConfig.height
+                        ? newConfig.bottom + newConfig.height
+                        : 0);
+                const popoverBottom =
+                    childRect.top +
+                    (newConfig.top && newConfig.height ? newConfig.top + newConfig.height : 0);
+                // 顶部安全距离不够，调整到底部
+                // @en The top safety distance is not enough, adjust to the bottom
+                if (directionState.indexOf('top') !== -1 && popoverTop < topOffset) {
+                    setToBottom();
+                } else if (
+                    // 底部安全距离不够，调整到顶部
+                    // @en The bottom safety distance is not enough, adjust to the top
+                    directionState.indexOf('bottom') !== -1 &&
+                    popoverBottom + bottomOffset > window.innerHeight
+                ) {
+                    setToTop();
+                }
             }
         }
 


### PR DESCRIPTION
This pull request refactors the `usePosition` hook in `usePosition.ts` to improve readability and maintainability by introducing helper functions for setting vertical positioning and adding logic to handle cases where there is insufficient space to display a popover.

### Improvements to vertical positioning logic:

* Introduced `setToBottom` and `setToTop` helper functions to encapsulate logic for adjusting the popover's position vertically, reducing code duplication.
* Added a new condition to handle cases where there is insufficient space both above and below the target element to display the popover. The logic now calculates available space above and below and adjusts the position accordingly.