### PR TITLE
chore: add DeepWiki badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ A comprehensive React UI components library based on the [Arco Design](https://a
 ![](https://img.shields.io/npm/v/@arco-design/mobile-react.svg?style=flat-square)
 ![](https://img.shields.io/npm/dm/@arco-design/mobile-react.svg?style=flat-square)
 [![license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/arco-design/arco-design-mobile/blob/main/LICENSE)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/arco-design/arco-design-mobile)
 
 </div>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -20,6 +20,7 @@
 ![](https://img.shields.io/npm/v/@arco-design/mobile-react.svg?style=flat-square)
 ![](https://img.shields.io/npm/dm/@arco-design/mobile-react.svg?style=flat-square)
 [![license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/arco-design/arco-design-mobile/blob/main/LICENSE)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/arco-design/arco-design-mobile)
 
 </div>
 


### PR DESCRIPTION
This pull request adds a new badge to the `README.md` and `README.zh-CN.md` files, linking to DeepWiki for additional project information.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R22): Added a "Ask DeepWiki" badge linking to the project's page on DeepWiki.
* [`README.zh-CN.md`](diffhunk://#diff-13f564fa6ce92394f8423bbcea359aef7e9ebc4f79763efc0d791d9ce5b6f987R23): Added the same "Ask DeepWiki" badge to the Chinese version of the README.