### PR TITLE
fix: `Carousel` swipping problem after setting "bounceWhenNoLoop"

### DIFF
--- a/packages/arcodesign/components/carousel/index.tsx
+++ b/packages/arcodesign/components/carousel/index.tsx
@@ -1034,11 +1034,6 @@ const Carousel = forwardRef((props: CarouselProps, ref: Ref<CarouselRef>) => {
             return;
         }
         stopPropagation && e.stopPropagation();
-        if (bouncingRef.current) {
-            bouncingRef.current = false;
-            jumpTo(index, false);
-            return;
-        }
         if (!touchStartedRef.current) {
             return;
         }
@@ -1048,6 +1043,13 @@ const Carousel = forwardRef((props: CarouselProps, ref: Ref<CarouselRef>) => {
             return;
         }
         touchMovedRef.current = false;
+        // bugfix: 回弹判断逻辑需在touchMovedRef标识重置逻辑之后，否则会在触发回弹后导致标识无法重置引起滑动判断问题
+        // @en bugfix: The logic for the bounce judgment needs to be after the touchMovedRef reset logic, otherwise it will cause the problem of slide judgment after the bounce is triggered.
+        if (bouncingRef.current) {
+            bouncingRef.current = false;
+            jumpTo(index, false);
+            return;
+        }
         if (posAdjustingRef.current || touchStoppedRef.current) {
             return;
         }


### PR DESCRIPTION
This pull request refactors the event handling logic in the `Carousel` component to improve code organization and behavior consistency. The changes primarily involve repositioning the handling of the `bouncingRef` state.

**Refactoring of event handling logic:**

* Moved the logic for handling `bouncingRef` from the `onTouchStart` event to the `onTouchEnd` event, ensuring that bouncing behavior is addressed at the appropriate stage of the touch interaction. (`packages/arcodesign/components/carousel/index.tsx`, [[1]](diffhunk://#diff-97117a9403be52511be91dea02493cea5d06ccb38d5e3d5c905b64583a368465L1037-L1041) [[2]](diffhunk://#diff-97117a9403be52511be91dea02493cea5d06ccb38d5e3d5c905b64583a368465R1046-R1050)