### PR TITLE
chore: fix pr preview actions

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -55,21 +55,43 @@ jobs:
               run: |
                   surge ./merged_output ${{ env.ARCO_SITE_DOMAIN }} --token $SURGE_TOKEN
 
-            - name: Find Comment
-              uses: peter-evans/find-comment@v2
-              id: fc
-              with:
-                  issue-number: ${{ github.event.pull_request.number }}
-                  comment-author: 'github-actions[bot]'
-                  body-includes: PR Preview Link
-
-            - name: Comment PR with Preview Link
-              uses: peter-evans/create-or-update-comment@v2
+            - name: Create PR Comment
+              uses: actions/github-script@v6
               env:
                   ARCO_SITE_DOMAIN: ${{ env.ARCO_SITE_DOMAIN }}
               with:
-                  issue-number: ${{ github.event.pull_request.number }}
-                  comment-id: ${{ steps.fc.outputs.comment-id }}
-                  edit-mode: replace
-                  body: |
-                      ✨ **PR Preview Link**: [https://${{ env.ARCO_SITE_DOMAIN }}](https://${{ env.ARCO_SITE_DOMAIN }})
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  script: |
+                      const previewUrl = `https://${process.env.ARCO_SITE_DOMAIN}`;
+                      const commentBody = `✨ **PR Preview Link**: [${previewUrl}](${previewUrl})`;
+
+                      // 获取已有的评论
+                      const { data: comments } = await github.rest.issues.listComments({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        issue_number: context.issue.number
+                      });
+
+                      // 查找是否有我们之前创建的评论
+                      const botComment = comments.find(comment => {
+                        return comment.user.type === 'Bot' && 
+                               comment.body.includes('PR Preview Link');
+                      });
+
+                      if (botComment) {
+                        // 更新已有评论
+                        await github.rest.issues.updateComment({
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          comment_id: botComment.id,
+                          body: commentBody
+                        });
+                      } else {
+                        // 创建新评论
+                        await github.rest.issues.createComment({
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          issue_number: context.issue.number,
+                          body: commentBody
+                        });
+                      }

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -60,7 +60,7 @@ jobs:
               run: |
                   surge ./merged_output ${{ env.ARCO_SITE_DOMAIN }} --token $SURGE_TOKEN
 
-            - name: Create PR Comment
+            - name: Create/Update PR Comment
               uses: actions/github-script@v6
               env:
                   ARCO_SITE_DOMAIN: ${{ env.ARCO_SITE_DOMAIN }}

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -4,8 +4,9 @@ on:
     pull_request:
 
 permissions:
-    contents: read
-    pull-requests: write # 允许写入PR评论的权限
+    contents: read # Read repository content for checkout 读取仓库内容用于检出代码
+    pull-requests: write # Write PR comments and status 写入PR评论和状态
+    issues: write # Create and update issue comments 创建和更新issue评论
 
 jobs:
     build-and-deploy:
@@ -37,16 +38,16 @@ jobs:
 
             - name: Merge output directories
               run: |
-                  # 合并文件
+                  # Merge files 合并文件
                   cp -R output_resource/* output/page/
-                  # 创建目标目录
+                  # Create target directories 创建目标目录
                   mkdir -p merged_output/mobile/react/arco-design/pc
                   mkdir -p merged_output/mobile/react/arco-design/mobile
-                  # 移动目录内容
+                  # Move directory contents 移动目录内容
                   mv output/page/home/* merged_output/mobile/react/
                   mv output/page/pc/* merged_output/mobile/react/arco-design/pc/
                   mv output/page/mobile/* merged_output/mobile/react/arco-design/mobile/
-                  # 创建重定向 HTML 文件
+                  # Create redirect HTML file 创建重定向 HTML 文件
                   echo '<html><head><meta http-equiv="refresh" content="0; url=/mobile/react/arco-design/pc/" /></head><body></body></html>' > merged_output/index.html
 
             - name: Install Surge
@@ -69,21 +70,21 @@ jobs:
                       const previewUrl = `https://${process.env.ARCO_SITE_DOMAIN}`;
                       const commentBody = `✨ **PR Preview Link**: [${previewUrl}](${previewUrl})`;
 
-                      // 获取已有的评论
+                      // Retrieve existing comments 获取已有的评论
                       const { data: comments } = await github.rest.issues.listComments({
                         owner: context.repo.owner,
                         repo: context.repo.repo,
                         issue_number: context.issue.number
                       });
 
-                      // 查找是否有我们之前创建的评论
+                      // Find if there's a comment created by us before 查找是否有我们之前创建的评论
                       const botComment = comments.find(comment => {
                         return comment.user.type === 'Bot' && 
                                comment.body.includes('PR Preview Link');
                       });
 
                       if (botComment) {
-                        // 更新已有评论
+                        // Update existing comment 更新已有评论
                         await github.rest.issues.updateComment({
                           owner: context.repo.owner,
                           repo: context.repo.repo,
@@ -91,7 +92,7 @@ jobs:
                           body: commentBody
                         });
                       } else {
-                        // 创建新评论
+                        // Create new comment 创建新评论
                         await github.rest.issues.createComment({
                           owner: context.repo.owner,
                           repo: context.repo.repo,

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -3,6 +3,10 @@ name: PR Preview
 on:
     pull_request:
 
+permissions:
+    contents: read
+    pull-requests: write # 允许写入PR评论的权限
+
 jobs:
     build-and-deploy:
         runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for PR previews to improve permissions handling and simplify the process of creating or updating comments with preview links. The main changes include adding explicit permissions and replacing the `peter-evans` actions with a custom script using `actions/github-script` for better flexibility and maintainability.

### Workflow Permissions Update:
* Added explicit `contents: read` and `pull-requests: write` permissions to the workflow, ensuring the necessary access for commenting on pull requests. (`.github/workflows/pr-preview.yml`, [.github/workflows/pr-preview.ymlR6-R9](diffhunk://#diff-737d2247cd4b3b6578d2c5413b555a5ca90f6aaa32613770ffdc146900d0469bR6-R9))

### Comment Handling Simplification:
* Replaced the `peter-evans/find-comment` and `peter-evans/create-or-update-comment` actions with a custom script using `actions/github-script`. The script checks for an existing bot comment with the PR preview link and either updates it or creates a new one, improving customization and control over comment management. (`.github/workflows/pr-preview.yml`, [.github/workflows/pr-preview.ymlL58-R101](diffhunk://#diff-737d2247cd4b3b6578d2c5413b555a5ca90f6aaa32613770ffdc146900d0469bL58-R101))