### PR TITLE
feat: add new locales "zh-TW", "zh-HK" and "zh-YUE"

### DIFF
--- a/packages/common-widgets/utils/locale/zh-HK.ts
+++ b/packages/common-widgets/utils/locale/zh-HK.ts
@@ -1,0 +1,113 @@
+import { ILocale } from './type';
+
+const defaultMessageTemplate = '%s 不是 %s 類型';
+const localeConfig: ILocale = {
+    locale: 'zh-HK',
+    LoadMore: {
+        loadMoreText: '載入更多',
+        loadingText: '正在努力載入中...',
+        noDataText: '沒有更多資料了',
+        failLoadText: '載入失敗，點擊重試',
+        prepareScrollText: '上拉',
+        prepareClickText: '點擊',
+    },
+    Picker: {
+        okText: '確定',
+        cancelText: '取消',
+    },
+    Tag: {
+        addTag: '新增標籤',
+    },
+    Dialog: {
+        okText: '確定',
+        cancelText: '取消',
+    },
+    SwipeLoad: {
+        normalText: '更多',
+        activeText: '放開查看',
+    },
+    PullRefresh: {
+        loadingText: '載入中...',
+        pullingText: '下拉即可重新整理',
+        finishText: '重新整理成功',
+        loosingText: '放開即可重新整理',
+    },
+    DropdownMenu: {
+        select: '請選擇',
+    },
+    Pagination: {
+        previousPage: '上一頁',
+        nextPage: '下一頁',
+    },
+    Image: {
+        loadError: '重試',
+    },
+    ImagePicker: {
+        loadError: '載入失敗',
+    },
+    SearchBar: {
+        placeholder: '請輸入要搜尋的內容',
+        cancelBtn: '取消',
+    },
+    Stepper: {
+        minusButtonName: '減少',
+        addButtonName: '增加',
+    },
+    Keyboard: {
+        confirm: '完成',
+    },
+    Form: {
+        required: '%s 為必填項',
+        type: {
+            email: defaultMessageTemplate,
+            url: defaultMessageTemplate,
+            string: defaultMessageTemplate,
+            number: defaultMessageTemplate,
+            array: defaultMessageTemplate,
+            object: defaultMessageTemplate,
+            boolean: defaultMessageTemplate,
+        },
+        number: {
+            min: '`%s` 不可小於 `%s`',
+            max: '`%s` 不可大於 `%s`',
+            equal: '`%s` 應該等於 `%s`',
+            range: '`%s` 應該在 `%s ~ %s` 範圍中',
+            positive: '`%s` 不可小於 0',
+            negative: '`%s` 不可大於 0',
+        },
+        string: {
+            max: '%s 不可超過 %s 個字元',
+            min: '%s 不可少於 %s 個字元',
+            len: '%s 字元個數應等於 %s',
+            equal: '%s 應該等於 `%s`',
+            match: '`%s` 應符合 %s 模式',
+            uppercase: '%s 需全為大寫字元',
+            lowercase: '%s 需全為小寫字元',
+            whitespace: '%s 不可全為空格',
+        },
+        array: {
+            max: '%s 陣列長度不可大於 %s',
+            min: '%s 陣列長度不可小於 %s',
+            len: '%s 陣列長度需等於 %s',
+            includes: '%s 應該包含 %s',
+            deepEqual: '%s 應該完全等於 %s',
+        },
+        object: {
+            deepEqual: '%s 應該完全等於 %s',
+            hasKeys: '%s 需包含必要欄位 %s',
+        },
+        boolean: {
+            equal: '%s 應該等於 `%s`',
+        },
+        pickerDefaultHint: '請選擇',
+    },
+    NavBar: {
+        backBtnAriaLabel: '返回',
+    },
+    Uploader: {
+        uploadBtn: '上載',
+        retryUpload: '重試',
+    },
+};
+
+export default localeConfig;

--- a/packages/common-widgets/utils/locale/zh-TW.ts
+++ b/packages/common-widgets/utils/locale/zh-TW.ts
@@ -1,0 +1,113 @@
+import { ILocale } from './type';
+
+const defaultMessageTemplate = '%s 不是 %s 類型';
+const localeConfig: ILocale = {
+    locale: 'zh-TW',
+    LoadMore: {
+        loadMoreText: '載入更多',
+        loadingText: '正在努力載入中...',
+        noDataText: '沒有更多資料了',
+        failLoadText: '載入失敗，點擊重試',
+        prepareScrollText: '上拉',
+        prepareClickText: '點擊',
+    },
+    Picker: {
+        okText: '確認',
+        cancelText: '取消',
+    },
+    Tag: {
+        addTag: '新增標籤',
+    },
+    Dialog: {
+        okText: '確認',
+        cancelText: '取消',
+    },
+    SwipeLoad: {
+        normalText: '更多',
+        activeText: '釋放檢視',
+    },
+    PullRefresh: {
+        loadingText: '載入中...',
+        pullingText: '下拉即可重新整理',
+        finishText: '重新整理成功',
+        loosingText: '釋放即可重新整理',
+    },
+    DropdownMenu: {
+        select: '請選擇',
+    },
+    Pagination: {
+        previousPage: '上一頁',
+        nextPage: '下一頁',
+    },
+    Image: {
+        loadError: '重試',
+    },
+    ImagePicker: {
+        loadError: '載入失敗',
+    },
+    SearchBar: {
+        placeholder: '請輸入要查詢的內容',
+        cancelBtn: '取消',
+    },
+    Stepper: {
+        minusButtonName: '減少',
+        addButtonName: '增加',
+    },
+    Keyboard: {
+        confirm: '完成',
+    },
+    Form: {
+        required: '%s 為必填項',
+        type: {
+            email: defaultMessageTemplate,
+            url: defaultMessageTemplate,
+            string: defaultMessageTemplate,
+            number: defaultMessageTemplate,
+            array: defaultMessageTemplate,
+            object: defaultMessageTemplate,
+            boolean: defaultMessageTemplate,
+        },
+        number: {
+            min: '`%s` 不可小於 `%s`',
+            max: '`%s` 不可大於 `%s`',
+            equal: '`%s` 應該等於 `%s`',
+            range: '`%s` 應該在 `%s ~ %s` 範圍中',
+            positive: '`%s` 不可小於 0',
+            negative: '`%s` 不可大於 0',
+        },
+        string: {
+            max: '%s 不可超過 %s 個字元',
+            min: '%s 不可少於 %s 個字元',
+            len: '%s 字元個數應等於 %s',
+            equal: '%s 應該等於 `%s`',
+            match: '`%s` 應匹配 %s 模式',
+            uppercase: '%s 需全為大寫字元',
+            lowercase: '%s 需全為小寫字元',
+            whitespace: '%s 不可全為空格',
+        },
+        array: {
+            max: '%s 陣列長度不可大於 %s',
+            min: '%s 陣列長度不可小於 %s',
+            len: '%s 陣列長度需等於 %s',
+            includes: '%s 應該包含 %s',
+            deepEqual: '%s 應該完全等於 %s',
+        },
+        object: {
+            deepEqual: '%s 應該完全等於 %s',
+            hasKeys: '%s 需包含必要欄位 %s',
+        },
+        boolean: {
+            equal: '%s 應該等於 `%s`',
+        },
+        pickerDefaultHint: '請選擇',
+    },
+    NavBar: {
+        backBtnAriaLabel: '返回',
+    },
+    Uploader: {
+        uploadBtn: '上傳',
+        retryUpload: '重試',
+    },
+};
+
+export default localeConfig;

--- a/packages/common-widgets/utils/locale/zh-YUE.ts
+++ b/packages/common-widgets/utils/locale/zh-YUE.ts
@@ -1,0 +1,113 @@
+import { ILocale } from './type';
+
+const defaultMessageTemplate = '%s 唔係 %s 類型';
+const localeConfig: ILocale = {
+    locale: 'zh-YUE',
+    LoadMore: {
+        loadMoreText: '載入更多',
+        loadingText: '努力載緊...',
+        noDataText: '冇更多資料喇',
+        failLoadText: '載入失敗，撳重試',
+        prepareScrollText: '上拉',
+        prepareClickText: '撳',
+    },
+    Picker: {
+        okText: '確認',
+        cancelText: '取消',
+    },
+    Tag: {
+        addTag: '加標籤',
+    },
+    Dialog: {
+        okText: '確認',
+        cancelText: '取消',
+    },
+    SwipeLoad: {
+        normalText: '更多',
+        activeText: '放手睇',
+    },
+    PullRefresh: {
+        loadingText: '載緊...',
+        pullingText: '向下拉就可以重新整理',
+        finishText: '重新整理成功',
+        loosingText: '放手就可以重新整理',
+    },
+    DropdownMenu: {
+        select: '請選擇',
+    },
+    Pagination: {
+        previousPage: '上一頁',
+        nextPage: '下一頁',
+    },
+    Image: {
+        loadError: '重試',
+    },
+    ImagePicker: {
+        loadError: '載入失敗',
+    },
+    SearchBar: {
+        placeholder: '請輸入要搵嘅內容',
+        cancelBtn: '取消',
+    },
+    Stepper: {
+        minusButtonName: '減少',
+        addButtonName: '增加',
+    },
+    Keyboard: {
+        confirm: '完成',
+    },
+    Form: {
+        required: '%s 係必填項',
+        type: {
+            email: defaultMessageTemplate,
+            url: defaultMessageTemplate,
+            string: defaultMessageTemplate,
+            number: defaultMessageTemplate,
+            array: defaultMessageTemplate,
+            object: defaultMessageTemplate,
+            boolean: defaultMessageTemplate,
+        },
+        number: {
+            min: '`%s` 唔可以細過 `%s`',
+            max: '`%s` 唔可以大過 `%s`',
+            equal: '`%s` 應該等於 `%s`',
+            range: '`%s` 應該喺 `%s ~ %s` 範圍入面',
+            positive: '`%s` 唔可以細過 0',
+            negative: '`%s` 唔可以大過 0',
+        },
+        string: {
+            max: '%s 唔可以超過 %s 個字元',
+            min: '%s 唔可以少過 %s 個字元',
+            len: '%s 字元個數應該等於 %s',
+            equal: '%s 應該等於 `%s`',
+            match: '`%s` 應該符合 %s 模式',
+            uppercase: '%s 需要全部大寫字元',
+            lowercase: '%s 需要全部小寫字元',
+            whitespace: '%s 唔可以全部係空格',
+        },
+        array: {
+            max: '%s 陣列長度唔可以大過 %s',
+            min: '%s 陣列長度唔可以細過 %s',
+            len: '%s 陣列長度需要等於 %s',
+            includes: '%s 應該包含 %s',
+            deepEqual: '%s 應該完全等於 %s',
+        },
+        object: {
+            deepEqual: '%s 應該完全等於 %s',
+            hasKeys: '%s 需要包含必要欄位 %s',
+        },
+        boolean: {
+            equal: '%s 應該等於 `%s`',
+        },
+        pickerDefaultHint: '請選擇',
+    },
+    NavBar: {
+        backBtnAriaLabel: '返回',
+    },
+    Uploader: {
+        uploadBtn: '上載',
+        retryUpload: '重試',
+    },
+};
+
+export default localeConfig;

--- a/sites/pc/static/md/i18n.en-US.md
+++ b/sites/pc/static/md/i18n.en-US.md
@@ -4,7 +4,6 @@ All component copywriting is in Chinese by default, and other languages can be u
 
 =====================
 
-
 Internationalization is achieved through the [ContextProvider](#/components/context-provider) component.
 
 ## Usage
@@ -15,15 +14,21 @@ import { ContextProvider } from '@arco-design/mobile-react';
 import enUS from '@arco-design/mobile-utils/esm/locale/en-US';
 
 ReactDOM.render(
-  <ContextProvider locale={enUS}>
-    <YourApp />
-  </ContextProvider>,
-  CONTAINER
+    <ContextProvider locale={enUS}>
+        <YourApp />
+    </ContextProvider>,
+    CONTAINER,
 );
 ```
 
 ## Supported languages
 
-Simplified Chinese/English
+-   Simplified Chinese (zh-CN) - Default
+-   Traditional Chinese (zh-TW)
+-   Hong Kong Traditional Chinese (zh-HK)
+-   Cantonese (zh-YUE)
+-   English (en-US)
+-   German (de)
+-   Spanish (es)
 
 If you have new language requirements, please submit an issue~

--- a/sites/pc/static/md/i18n.md
+++ b/sites/pc/static/md/i18n.md
@@ -4,7 +4,6 @@
 
 =====================
 
-
 通过 [ContextProvider](#/components/context-provider) 组件实现国际化。
 
 ## 用法
@@ -15,15 +14,21 @@ import { ContextProvider } from '@arco-design/mobile-react';
 import enUS from '@arco-design/mobile-utils/esm/locale/en-US';
 
 ReactDOM.render(
-  <ContextProvider locale={enUS}>
-    <YourApp />
-  </ContextProvider>,
-  CONTAINER
+    <ContextProvider locale={enUS}>
+        <YourApp />
+    </ContextProvider>,
+    CONTAINER,
 );
 ```
 
 ## 支持的语言
 
-简体中文/英文
+-   简体中文 (zh-CN) - 默认语言
+-   繁体中文 (zh-TW)
+-   香港繁体中文 (zh-HK)
+-   粤语 (zh-YUE)
+-   英文 (en-US)
+-   德文 (de)
+-   西班牙文 (es)
 
-如果有新的语言需求，请提 issue～
+如果有新的语言需求，请提 issue ～


### PR DESCRIPTION
ref #345 

This pull request adds support for additional Chinese language variants and updates documentation to reflect these changes. Specifically, it introduces new locale configuration files for Traditional Chinese (zh-TW), Hong Kong Traditional Chinese (zh-HK), and Cantonese (zh-YUE), each providing localized strings for UI components and validation messages. The documentation is also updated to list all supported languages in both English and Chinese guides.

**Locale support enhancements:**

* Added `zh-TW` (Traditional Chinese) locale configuration with component and validation messages in `packages/common-widgets/utils/locale/zh-TW.ts`.
* Added `zh-HK` (Hong Kong Traditional Chinese) locale configuration with region-specific translations in `packages/common-widgets/utils/locale/zh-HK.ts`.
* Added `zh-YUE` (Cantonese) locale configuration with dialect-specific phrasing in `packages/common-widgets/utils/locale/zh-YUE.ts`.

**Documentation updates:**

* Updated English documentation in `sites/pc/static/md/i18n.en-US.md` to list all supported languages, including the new Chinese variants.
* Updated Chinese documentation in `sites/pc/static/md/i18n.md` to list all supported languages, including the new Chinese variants.

**Minor documentation formatting:**

* Removed unnecessary blank lines in both English and Chinese documentation for clarity. [[1]](diffhunk://#diff-61498a92f04d6c713b6914b0e1802f39714ab799296a1ec5277e189bc96129ffL7) [[2]](diffhunk://#diff-9af2204deb6261059ca29409cb5b8b62e15f49848413ba4b2670c529169817ecL7)