### PR TITLE
fix: `Sticky` add tolerance when judging sticky state

### DIFF
--- a/packages/arcodesign/components/sticky/index.tsx
+++ b/packages/arcodesign/components/sticky/index.tsx
@@ -216,21 +216,25 @@ const Sticky = forwardRef((props: StickyProps, ref: Ref<StickyRef>) => {
             const containerTop = rectTop + borderTop;
             const containerBottom = rectBottom - borderBottom;
 
-            const disFromTop = Math.round(placeholderClientRect.top - containerTop);
-            const disFromBottom = Math.round(
-                placeholderClientRect.top + calculatedHeight - containerBottom,
-            );
+            // 使用容差阈值避免iOS阻尼动画时的抖动问题
+            // @en Tolerance threshold to avoid jitter problem in iOS damping animation
+            const TOLERANCE = 0.5;
+            const disFromTop = placeholderClientRect.top - containerTop;
+            const disFromBottom = placeholderClientRect.top + calculatedHeight - containerBottom;
+
             const topFollowDifference =
                 followBottom - followOffset - calculatedHeight - topOffset - containerTop;
             const bottomFollowDifference =
                 containerHeight - followTop - followOffset - calculatedHeight - bottomOffset;
-
             setWasSticky(Boolean(isStickyRef.current));
+
             const isTopSticky = needTop
-                ? disFromTop <= topOffset && followBottom > containerTop + followOffset
+                ? disFromTop <= topOffset + TOLERANCE &&
+                  followBottom > containerTop + followOffset - TOLERANCE
                 : false;
             const isBottomSticky = needBottom
-                ? disFromBottom >= -bottomOffset && followTop < containerBottom - followOffset
+                ? disFromBottom >= -bottomOffset - TOLERANCE &&
+                  followTop < containerBottom - followOffset + TOLERANCE
                 : false;
             const newStickyState = isTopSticky || isBottomSticky;
 


### PR DESCRIPTION
This pull request addresses a UI issue with the `Sticky` component in `index.tsx` by introducing a tolerance threshold to prevent jitter during iOS damping animations. The main change is to adjust the sticky position calculations to be less sensitive to minor pixel differences, which helps avoid unwanted visual shaking on iOS devices.

**Sticky positioning improvements:**

* Added a `TOLERANCE` constant to the sticky position calculations to avoid jitter caused by iOS damping animation, improving user experience on iOS devices.
* Updated the logic for determining `isTopSticky` and `isBottomSticky` to include the tolerance threshold, making sticky state transitions smoother and less prone to flickering.