### PR TITLE
fix: add new locale "it"

### DIFF
--- a/packages/common-widgets/utils/locale/it.ts
+++ b/packages/common-widgets/utils/locale/it.ts
@@ -1,0 +1,114 @@
+import type { ILocale } from './type';
+
+const defaultMessageTemplate = '%s non è un tipo %s';
+
+const localeConfig: ILocale = {
+    locale: 'it',
+    LoadMore: {
+        loadMoreText: ' per caricare di più',
+        loadingText: 'Caricamento...',
+        noDataText: 'Nessun altro dato',
+        failLoadText: 'Caricamento fallito, clicca per riprovare',
+        prepareScrollText: 'Tira su',
+        prepareClickText: 'Clicca',
+    },
+    Picker: {
+        okText: 'OK',
+        cancelText: 'Annulla',
+    },
+    Tag: {
+        addTag: 'Aggiungi Tag',
+    },
+    Dialog: {
+        okText: 'OK',
+        cancelText: 'Annulla',
+    },
+    SwipeLoad: {
+        normalText: 'Di più',
+        activeText: 'Rilascia per visualizzare',
+    },
+    PullRefresh: {
+        loadingText: 'Caricamento...',
+        pullingText: 'Tira per aggiornare',
+        finishText: 'Aggiornamento riuscito',
+        loosingText: 'Rilascia per aggiornare',
+    },
+    DropdownMenu: {
+        select: 'Seleziona',
+    },
+    Pagination: {
+        previousPage: 'Precedente',
+        nextPage: 'Successivo',
+    },
+    Image: {
+        loadError: 'Riprova',
+    },
+    ImagePicker: {
+        loadError: 'Caricamento fallito',
+    },
+    SearchBar: {
+        placeholder: 'Inserisci il contenuto da cercare',
+        cancelBtn: 'Annulla',
+    },
+    Stepper: {
+        minusButtonName: 'diminuisci',
+        addButtonName: 'aumenta',
+    },
+    Keyboard: {
+        confirm: 'Fatto',
+    },
+    Form: {
+        required: '%s è obbligatorio',
+        type: {
+            email: defaultMessageTemplate,
+            url: defaultMessageTemplate,
+            string: defaultMessageTemplate,
+            number: defaultMessageTemplate,
+            array: defaultMessageTemplate,
+            object: defaultMessageTemplate,
+            boolean: defaultMessageTemplate,
+        },
+        number: {
+            min: '`%s` deve essere almeno `%s`',
+            max: '`%s` non deve superare `%s`',
+            equal: '`%s` deve essere uguale a `%s`',
+            range: "`%s` deve essere nell'intervallo `%s ~ %s`",
+            positive: '`%s` non può essere minore di 0',
+            negative: '`%s` non può essere maggiore di 0',
+        },
+        string: {
+            max: '%s non può essere più lungo di %s caratteri',
+            min: '%s deve essere almeno %s caratteri',
+            len: '%s deve essere esattamente %s caratteri',
+            equal: '%s deve essere uguale a `%s`',
+            match: '`%s` non corrisponde al pattern %s',
+            uppercase: '%s deve essere tutto maiuscolo',
+            lowercase: '%s deve essere tutto minuscolo',
+            whitespace: '%s non può essere una stringa di spazi vuoti',
+        },
+        array: {
+            max: '%s non può essere maggiore di %s in lunghezza',
+            min: '%s non può essere minore di %s in lunghezza',
+            len: '%s deve essere esattamente %s in lunghezza',
+            includes: '%s non include %s',
+            deepEqual: '%s non è profondamente uguale a %s',
+        },
+        object: {
+            deepEqual: '%s non è profondamente uguale a %s',
+            hasKeys: '%s non contiene i campi richiesti %s',
+        },
+        boolean: {
+            equal: '%s deve essere uguale a `%s`',
+        },
+        pickerDefaultHint: 'Seleziona',
+    },
+    NavBar: {
+        backBtnAriaLabel: 'Indietro',
+    },
+    Uploader: {
+        uploadBtn: 'Carica',
+        retryUpload: 'Riprova',
+    },
+};
+
+export default localeConfig;

--- a/packages/common-widgets/utils/locale/it.ts
+++ b/packages/common-widgets/utils/locale/it.ts
@@ -81,7 +81,7 @@ const localeConfig: ILocale = {
             min: '%s deve essere almeno %s caratteri',
             len: '%s deve essere esattamente %s caratteri',
             equal: '%s deve essere uguale a `%s`',
-            match: '`%s` non corrisponde al pattern %s',
+            match: '`%s` non corrisponde al formato %s',
             uppercase: '%s deve essere tutto maiuscolo',
             lowercase: '%s deve essere tutto minuscolo',
             whitespace: '%s non può essere una stringa di spazi vuoti',

--- a/sites/pc/static/md/i18n.en-US.md
+++ b/sites/pc/static/md/i18n.en-US.md
@@ -30,5 +30,6 @@ ReactDOM.render(
 -   English (en-US)
 -   German (de)
 -   Spanish (es)
+-   Italian (it)
 
 If you have new language requirements, please submit an issue~

--- a/sites/pc/static/md/i18n.md
+++ b/sites/pc/static/md/i18n.md
@@ -30,5 +30,6 @@ ReactDOM.render(
 -   英文 (en-US)
 -   德文 (de)
 -   西班牙文 (es)
+-   意大利文 (it)
 
 如果有新的语言需求，请提 issue ～


### PR DESCRIPTION
This pull request adds support for the Italian (`it`) locale to the common widgets package and updates the documentation to reflect this new language option. The main change is the introduction of a comprehensive Italian translation file for UI components and validation messages.

**Italian locale support:**

* Added a new file `packages/common-widgets/utils/locale/it.ts` containing Italian translations for all UI components and form validation messages.

**Documentation updates:**

* Updated the English documentation (`sites/pc/static/md/i18n.en-US.md`) to include Italian (`it`) in the list of supported languages.
* Updated the Chinese documentation (`sites/pc/static/md/i18n.md`) to include Italian (`it`) in the list of supported languages.