### PR TITLE
fix: add French (fr) locale to mobile-utils

### DIFF
--- a/packages/common-widgets/utils/locale/de.ts
+++ b/packages/common-widgets/utils/locale/de.ts
@@ -1,4 +1,4 @@
-import { ILocale } from './type';
+import type { ILocale } from './type';
 
 const defaultMessageTemplate = '%s ist nicht vom Typ %s';
 const localeConfig: ILocale = {

--- a/packages/common-widgets/utils/locale/en-US.ts
+++ b/packages/common-widgets/utils/locale/en-US.ts
@@ -1,4 +1,4 @@
-import { ILocale } from './type';
+import type { ILocale } from './type';
 
 const defaultMessageTemplate = '%s is not a %s type';
 

--- a/packages/common-widgets/utils/locale/es.ts
+++ b/packages/common-widgets/utils/locale/es.ts
@@ -1,4 +1,4 @@
-import { ILocale } from './type';
+import type { ILocale } from './type';
 
 const defaultMessageTemplate = '%s no es del tipo %s';
 const localeConfig: ILocale = {

--- a/packages/common-widgets/utils/locale/fr.ts
+++ b/packages/common-widgets/utils/locale/fr.ts
@@ -1,0 +1,114 @@
+import type { ILocale } from './type';
+
+const defaultMessageTemplate = "%s n'est pas du type %s";
+
+const localeConfig: ILocale = {
+    locale: 'fr',
+    LoadMore: {
+        loadMoreText: ' pour charger davantage',
+        loadingText: 'Chargement...',
+        noDataText: 'Aucune autre donnée',
+        failLoadText: 'Échec du chargement, cliquez pour réessayer',
+        prepareScrollText: 'Tirer vers le haut',
+        prepareClickText: 'Cliquez',
+    },
+    Picker: {
+        okText: 'Confirmer',
+        cancelText: 'Annuler',
+    },
+    Tag: {
+        addTag: 'Ajouter une étiquette',
+    },
+    Dialog: {
+        okText: 'Confirmer',
+        cancelText: 'Annuler',
+    },
+    SwipeLoad: {
+        normalText: 'Voir plus',
+        activeText: 'Relâcher pour voir',
+    },
+    PullRefresh: {
+        loadingText: 'Chargement...',
+        pullingText: 'Tirer pour actualiser',
+        finishText: 'Actualisation réussie',
+        loosingText: 'Relâcher pour actualiser',
+    },
+    DropdownMenu: {
+        select: 'Veuillez sélectionner',
+    },
+    Pagination: {
+        previousPage: 'Page précédente',
+        nextPage: 'Page suivante',
+    },
+    Image: {
+        loadError: 'Réessayer',
+    },
+    ImagePicker: {
+        loadError: 'Échec du chargement',
+    },
+    SearchBar: {
+        placeholder: 'Veuillez saisir le contenu à rechercher',
+        cancelBtn: 'Annuler',
+    },
+    Stepper: {
+        minusButtonName: 'diminuer',
+        addButtonName: 'augmenter',
+    },
+    Keyboard: {
+        confirm: 'Terminé',
+    },
+    Form: {
+        required: '%s est requis',
+        type: {
+            email: defaultMessageTemplate,
+            url: defaultMessageTemplate,
+            string: defaultMessageTemplate,
+            number: defaultMessageTemplate,
+            array: defaultMessageTemplate,
+            object: defaultMessageTemplate,
+            boolean: defaultMessageTemplate,
+        },
+        number: {
+            min: '`%s` doit être au moins `%s`',
+            max: '`%s` ne doit pas dépasser `%s`',
+            equal: '`%s` doit être égal à `%s`',
+            range: '`%s` doit être compris entre `%s` et `%s`',
+            positive: '`%s` ne peut pas être inférieur à 0',
+            negative: '`%s` ne peut pas être supérieur à 0',
+        },
+        string: {
+            max: '%s ne peut pas dépasser %s caractères',
+            min: '%s doit comporter au moins %s caractères',
+            len: '%s doit comporter exactement %s caractères',
+            equal: '%s doit être égal à `%s`',
+            match: '`%s` ne correspond pas au format %s',
+            uppercase: '%s doit être entièrement en majuscules',
+            lowercase: '%s doit être entièrement en minuscules',
+            whitespace: "%s ne peut pas être une chaîne d'espaces",
+        },
+        array: {
+            max: 'La longueur de %s ne peut pas dépasser %s',
+            min: 'La longueur de %s ne peut pas être inférieure à %s',
+            len: 'La longueur de %s doit être exactement %s',
+            includes: '%s ne contient pas %s',
+            deepEqual: "%s n'est pas strictement égal à %s",
+        },
+        object: {
+            deepEqual: "%s n'est pas strictement égal à %s",
+            hasKeys: '%s ne contient pas les champs requis %s',
+        },
+        boolean: {
+            equal: '%s doit être égal à `%s`',
+        },
+        pickerDefaultHint: 'Veuillez sélectionner',
+    },
+    NavBar: {
+        backBtnAriaLabel: 'Retour',
+    },
+    Uploader: {
+        uploadBtn: 'Téléverser',
+        retryUpload: 'Réessayer',
+    },
+};
+
+export default localeConfig;

--- a/packages/common-widgets/utils/locale/zh-CN.ts
+++ b/packages/common-widgets/utils/locale/zh-CN.ts
@@ -1,4 +1,4 @@
-import { ILocale } from './type';
+import type { ILocale } from './type';
 
 const defaultMessageTemplate = '%s 不是 %s 类型';
 const localeConfig: ILocale = {

--- a/packages/common-widgets/utils/locale/zh-HK.ts
+++ b/packages/common-widgets/utils/locale/zh-HK.ts
@@ -1,4 +1,4 @@
-import { ILocale } from './type';
+import type { ILocale } from './type';
 
 const defaultMessageTemplate = '%s 不是 %s 類型';
 const localeConfig: ILocale = {

--- a/packages/common-widgets/utils/locale/zh-TW.ts
+++ b/packages/common-widgets/utils/locale/zh-TW.ts
@@ -1,4 +1,4 @@
-import { ILocale } from './type';
+import type { ILocale } from './type';
 
 const defaultMessageTemplate = '%s 不是 %s 類型';
 const localeConfig: ILocale = {

--- a/packages/common-widgets/utils/locale/zh-YUE.ts
+++ b/packages/common-widgets/utils/locale/zh-YUE.ts
@@ -1,4 +1,4 @@
-import { ILocale } from './type';
+import type { ILocale } from './type';
 
 const defaultMessageTemplate = '%s 唔係 %s 類型';
 const localeConfig: ILocale = {

--- a/packages/common-widgets/utils/validator/message.ts
+++ b/packages/common-widgets/utils/validator/message.ts
@@ -1,5 +1,5 @@
 import { isObject } from '../is';
-import { IValidateMsgTemplate } from './type';
+import type { IValidateMsgTemplate } from './type';
 
 const defaultMessageTemplate = '%s is not a %s type';
 

--- a/sites/pc/static/md/i18n.en-US.md
+++ b/sites/pc/static/md/i18n.en-US.md
@@ -31,5 +31,6 @@ ReactDOM.render(
 -   German (de)
 -   Spanish (es)
 -   Italian (it)
+-   French (fr)
 
 If you have new language requirements, please submit an issue~

--- a/sites/pc/static/md/i18n.md
+++ b/sites/pc/static/md/i18n.md
@@ -31,5 +31,6 @@ ReactDOM.render(
 -   德文 (de)
 -   西班牙文 (es)
 -   意大利文 (it)
+-   法文 (fr)
 
 如果有新的语言需求，请提 issue ～


### PR DESCRIPTION
## Summary
- Add French (`fr`) locale config under `packages/common-widgets/utils/locale/fr.ts`, following the existing pattern of `es.ts` / `de.ts` / `it.ts`.
- Covers all `ILocale` keys: `LoadMore`, `Picker`, `Tag`, `Dialog`, `SwipeLoad`, `PullRefresh`, `DropdownMenu`, `Pagination`, `Image`, `ImagePicker`, `SearchBar`, `Stepper`, `Keyboard`, `Form`, `NavBar`, `Uploader`.

## Test plan
- [ ] Type check passes (`ILocale` interface fully implemented).
- [ ] Import `@arco-design/mobile-utils/utils/locale/fr` and confirm components render French strings via `ContextProvider`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)